### PR TITLE
886689 - puppet distributor output from the CLI now includes a relative ...

### DIFF
--- a/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/cudl.py
+++ b/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/cudl.py
@@ -159,6 +159,10 @@ class ListPuppetRepositoriesCommand(ListRepositoriesCommand):
             if constants.REPO_NOTE_KEY in notes and notes[constants.REPO_NOTE_KEY] == constants.REPO_NOTE_PUPPET:
                 puppet_repos.append(repo)
 
+        for repo in puppet_repos:
+            if repo.get('distributors'):
+                repo['distributors'][0]['relative_path'] = 'puppet/%s/' % repo['id']
+
         return puppet_repos
 
     def get_other_repositories(self, query_params, **kwargs):

--- a/pulp_puppet_extensions_admin/test/unit/test_extension_repo.py
+++ b/pulp_puppet_extensions_admin/test/unit/test_extension_repo.py
@@ -189,10 +189,10 @@ class ListPuppetRepositoriesCommandTests(base_cli.ExtensionTests):
     def test_get_repositories(self):
         # Setup
         repos = [
-            {'repo_id' : 'repo-1', 'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET}},
-            {'repo_id' : 'repo-2', 'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET}},
-            {'repo_id' : 'repo-3', 'notes' : {constants.REPO_NOTE_KEY : 'rpm'}},
-            {'repo_id' : 'repo-4', 'notes' : {}},
+            {'id' : 'repo-1', 'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET}},
+            {'id' : 'repo-2', 'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET}},
+            {'id' : 'repo-3', 'notes' : {constants.REPO_NOTE_KEY : 'rpm'}},
+            {'id' : 'repo-4', 'notes' : {}},
         ]
 
         self.server_mock.request.return_value = 200, repos
@@ -203,16 +203,16 @@ class ListPuppetRepositoriesCommandTests(base_cli.ExtensionTests):
         # Verify
         self.assertEqual(2, len(repos))
 
-        repo_ids = [r['repo_id'] for r in repos]
+        repo_ids = [r['id'] for r in repos]
         self.assertTrue('repo-1' in repo_ids)
         self.assertTrue('repo-2' in repo_ids)
 
     def test_get_other_repositories(self):
         # Setup
         repos = [
-            {'repo_id' : 'repo-1', 'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET}},
-            {'repo_id' : 'repo-2', 'notes' : {constants.REPO_NOTE_KEY : 'rpm'}},
-            {'repo_id' : 'repo-3', 'notes' : {}},
+            {'id' : 'repo-1', 'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET}},
+            {'id' : 'repo-2', 'notes' : {constants.REPO_NOTE_KEY : 'rpm'}},
+            {'id' : 'repo-3', 'notes' : {}},
             ]
 
         self.server_mock.request.return_value = 200, repos
@@ -223,9 +223,29 @@ class ListPuppetRepositoriesCommandTests(base_cli.ExtensionTests):
         # Verify
         self.assertEqual(2, len(repos))
 
-        repo_ids = [r['repo_id'] for r in repos]
+        repo_ids = [r['id'] for r in repos]
         self.assertTrue('repo-2' in repo_ids)
         self.assertTrue('repo-3' in repo_ids)
+
+    def test_get_with_distributors(self):
+        # Setup
+        repos = [
+            {
+                'id' : 'repo-1',
+                'notes' : {constants.REPO_NOTE_KEY : constants.REPO_NOTE_PUPPET},
+                'distributors': [{}],
+            },
+        ]
+
+        self.server_mock.request.return_value = 200, repos
+
+        # Test
+        repos = self.command.get_repositories({})
+
+        # make sure the "relative_path" attribute was added correctly
+        # to the distributor
+        self.assertEqual(
+            repos[0]['distributors'][0].get('relative_path'), 'puppet/repo-1/')
 
 
 class SearchPuppetRepositoriesCommand(base_cli.ExtensionTests):


### PR DESCRIPTION
...path to the published content.

https://bugzilla.redhat.com/show_bug.cgi?id=886689
