### PR TITLE
861211 - Adding a "--queries" option to repo create and update that take...

### DIFF
--- a/docs/user-guide/quick-start.rst
+++ b/docs/user-guide/quick-start.rst
@@ -32,9 +32,12 @@ Update a Repository
 
 Let's add a query to limit the scope of how many modules get synced.
 
+.. note::
+  The ``--query`` option was deprecated in version 2.1
+
 ::
 
-  $ pulp-admin puppet repo update --repo-id=repo1 --query=libvirt
+  $ pulp-admin puppet repo update --repo-id=repo1 --queries=libvirt
   Repository [repo1] successfully updated
 
 List Repositories


### PR DESCRIPTION
...s a CSV list of query terms, and deprecating the previous "--query" option.

https://bugzilla.redhat.com/show_bug.cgi?id=861211
