### PR TITLE
removing fancy asserts that apparently aren't in python 2.6, and mocking...

### DIFF
--- a/pulp_puppet_plugins/test/unit/test_distributor_publish.py
+++ b/pulp_puppet_plugins/test/unit/test_distributor_publish.py
@@ -157,10 +157,10 @@ class PublishRunTests(unittest.TestCase):
             name = '%s/%s' % (unit.unit_key['author'], unit.unit_key['name'])
             self.assertTrue(db.has_key(name))
             data = json.loads(db[name])
-            self.assertIsInstance(data, list)
+            self.assertTrue(isinstance(data, list))
             if len(data) == 1:
                 self.assertEqual(data[0]['version'], unit.unit_key['version'])
-                self.assertIsInstance(data[0].get('dependencies'), list)
+                self.assertTrue(isinstance(data[0].get('dependencies'), list))
                 self.assertTrue('file' in data[0])
         db.close()
 

--- a/pulp_puppet_plugins/test/unit/test_forge_api.py
+++ b/pulp_puppet_plugins/test/unit/test_forge_api.py
@@ -77,7 +77,7 @@ class TestGET(unittest.TestCase):
         mock_ctx.env = {}
 
         result = api.Releases().GET()
-        self.assertIsInstance(result, web.webapi.Unauthorized)
+        self.assertTrue(isinstance(result, web.webapi.Unauthorized))
 
     @mock.patch('web.ctx')
     @mock.patch.object(api.Releases, '_get_credentials')
@@ -88,7 +88,7 @@ class TestGET(unittest.TestCase):
         mock_ctx.env = {}
 
         result = api.Releases().GET()
-        self.assertIsInstance(result, web.webapi.BadRequest)
+        self.assertTrue(isinstance(result, web.webapi.BadRequest))
 
     @mock.patch('pulp_puppet.forge.releases.view', autospec=True)
     @mock.patch.object(web, 'input')
@@ -132,13 +132,13 @@ class TestGetCredentials(unittest.TestCase):
     def test_invalid_string(self, mock_ctx):
         mock_ctx.env = {'HTTP_AUTHORIZATION' : 'Basic notreallyencoded'}
         result = api.Releases._get_credentials()
-        self.assertIsNone(result)
+        self.assertTrue(result is None)
 
     @mock.patch('web.ctx')
     def test_not_provided(self, mock_ctx):
         mock_ctx.env = {}
         result = api.Releases._get_credentials()
-        self.assertIsNone(result)
+        self.assertTrue(result is None)
 
 
 class TestGetModuleName(unittest.TestCase):
@@ -153,5 +153,5 @@ class TestGetModuleName(unittest.TestCase):
     def test_not_provided(self, mock_input):
         result = api.Releases._get_module_name()
 
-        self.assertIsNone(result)
+        self.assertTrue(result is None)
         mock_input.assert_called_once_with()

--- a/pulp_puppet_plugins/test/unit/test_forge_releases.py
+++ b/pulp_puppet_plugins/test/unit/test_forge_releases.py
@@ -37,7 +37,8 @@ MOCK_HOST_PROTOCOL = {
 
 
 class TestView(unittest.TestCase):
-    def test_null_auth(self):
+    @mock.patch('web.webapi.ctx')
+    def test_null_auth(self, mock_ctx):
         self.assertRaises(
             web.Unauthorized, releases.view, releases.NULL_AUTH_VALUE,
             releases.NULL_AUTH_VALUE, 'foo/bar')
@@ -98,7 +99,7 @@ class TestGetRepoData(unittest.TestCase):
 
         result = releases.get_repo_data(['repo1'])
 
-        self.assertIsInstance(result, dict)
+        self.assertTrue(isinstance(result, dict))
         self.assertEqual(result.keys(), ['repo1'])
         self.assertEqual(result['repo1']['db'], mock_open.return_value)
         mock_open.assert_called_once_with('/var/www/pulp_puppet/http/repos/repo1/.dependency_db', 'r')
@@ -209,7 +210,7 @@ class TestFindVersion(unittest.TestCase):
 
         result = releases.find_version(['repo1', 'repo2'], 'foo/bar', '2.0.3')
 
-        self.assertIsInstance(result, Unit)
+        self.assertTrue(isinstance(result, Unit))
         self.assertEqual(result.version, '2.0.3')
 
     @mock.patch.object(releases, 'get_host_and_protocol')
@@ -225,7 +226,7 @@ class TestFindVersion(unittest.TestCase):
 
         result = releases.find_version(['repo1', 'repo2'], 'foo/bar', '1.0.0')
 
-        self.assertIsNone(result)
+        self.assertTrue(result is None)
 
     @mock.patch.object(releases, 'get_host_and_protocol')
     @mock.patch('pulp_puppet.forge.unit.Unit.units_from_json', side_effect=Exception)
@@ -281,7 +282,7 @@ class TestFindNewest(unittest.TestCase):
 
         result = releases.find_newest(['repo1', 'repo2'], 'foo/bar')
 
-        self.assertIsInstance(result, Unit)
+        self.assertTrue(isinstance(result, Unit))
         self.assertEqual(result.version, '3.1.5')
 
     @mock.patch.object(releases, 'get_host_and_protocol')
@@ -297,7 +298,7 @@ class TestFindNewest(unittest.TestCase):
 
         result = releases.find_newest(['repo1', 'repo2'], 'foo/bar')
 
-        self.assertIsNone(result)
+        self.assertTrue(result is None)
 
     @mock.patch.object(releases, 'get_host_and_protocol')
     @mock.patch('pulp_puppet.forge.unit.Unit.units_from_json', side_effect=Exception)

--- a/pulp_puppet_plugins/test/unit/test_forge_unit.py
+++ b/pulp_puppet_plugins/test/unit/test_forge_unit.py
@@ -44,7 +44,7 @@ class TestUnitsFromJSON(unittest.TestCase):
         result = Unit.units_from_json(name, db, 'repo1', 'localhost', 'http')
 
         self.assertEqual(len(result), 1)
-        self.assertIsInstance(result[0], Unit)
+        self.assertTrue(isinstance(result[0], Unit))
         self.assertEqual(result[0].name, name)
         self.assertEqual(result[0].repo_id, 'repo1')
         self.assertEqual(result[0].host, 'localhost')
@@ -115,7 +115,7 @@ class TestDepsAsList(unittest.TestCase):
         unit = unit_generator()
         result = unit._deps_as_list
 
-        self.assertIsInstance(result, list)
+        self.assertTrue(isinstance(result, list))
         self.assertEqual(len(result), 1)
         self.assertEqual(len(result[0]), 2)
         self.assertEqual(result[0][0], unit.dependencies[0]['name'])


### PR DESCRIPTION
... for a behavior that changed from web.py 0.36 to 0.37.
