### PR TITLE
902514 - Removed the <VirtualHost> block, which apache was ignoring anyw...

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -36,6 +36,7 @@ DIR_PLUGINS = '/usr/lib/pulp/plugins'
 
 LINKS = (
     ('pulp_puppet_plugins/etc/httpd/conf.d/puppet.conf', '/etc/httpd/conf.d/puppet.conf'),
+    ('pulp_puppet_plugins/etc/pulp/vhosts80/puppet.conf', '/etc/pulp/vhosts80/puppet.conf'),
     ('pulp_puppet_plugins/srv/pulp/puppet_forge_api.wsgi', '/srv/pulp/puppet_forge_api.wsgi'),
     # Puppet Support Plugins
     ('pulp_puppet_plugins/pulp_puppet/plugins/types/puppet.json', DIR_PLUGINS + '/types/puppet.json'),

--- a/pulp-puppet.spec
+++ b/pulp-puppet.spec
@@ -75,6 +75,7 @@ popd
 
 # Directories
 mkdir -p %{buildroot}/%{_sysconfdir}/pulp/agent/conf.d
+mkdir -p %{buildroot}/%{_sysconfdir}/pulp/vhosts80
 mkdir -p %{buildroot}/%{_usr}/lib
 mkdir -p %{buildroot}/%{_usr}/lib/pulp/plugins/types
 mkdir -p %{buildroot}/%{_usr}/lib/pulp/admin/extensions
@@ -86,6 +87,7 @@ mkdir -p %{buildroot}/%{_var}/www/pulp_puppet/https
 # Configuration
 cp -R pulp_puppet_plugins/etc/httpd %{buildroot}/%{_sysconfdir}
 cp -R pulp_puppet_extensions_admin/etc/pulp %{buildroot}/%{_sysconfdir}
+cp pulp_puppet_plugins/etc/pulp/vhosts80/puppet.conf %{buildroot}/%{_sysconfdir}/pulp/vhosts80/
 
 # Agent Handlers
 cp pulp_puppet_handlers/etc/pulp/agent/conf.d/* %{buildroot}/%{_sysconfdir}/pulp/agent/conf.d/
@@ -150,6 +152,7 @@ to provide Puppet specific support.
 %files plugins
 
 %defattr(-,root,root,-)
+%{_sysconfdir}/pulp/vhosts80/puppet.conf
 %{python_sitelib}/pulp_puppet/forge/
 %{python_sitelib}/pulp_puppet/plugins/
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/puppet.conf

--- a/pulp_puppet_plugins/etc/httpd/conf.d/puppet.conf
+++ b/pulp_puppet_plugins/etc/httpd/conf.d/puppet.conf
@@ -25,10 +25,6 @@ Alias /pulp/puppet /var/www/pulp_puppet/https/repos
 
 # -- HTTP Repositories ----------
 
-<VirtualHost *:80>
-    Alias /pulp/puppet /var/www/pulp_puppet/http/repos
-</VirtualHost>
-
 <Directory /var/www/pulp_puppet/http/repos>
     Options FollowSymLinks Indexes
 </Directory>

--- a/pulp_puppet_plugins/etc/pulp/vhosts80/puppet.conf
+++ b/pulp_puppet_plugins/etc/pulp/vhosts80/puppet.conf
@@ -1,0 +1,1 @@
+Alias /pulp/puppet /var/www/pulp_puppet/http/repos


### PR DESCRIPTION
...ay, in favor of using the platform's authoritative one.

https://bugzilla.redhat.com/show_bug.cgi?id=902514

Please review this with its corresponding PRs in each of the other two repos.
