### PR TITLE
Updated for polling-based remove command

### DIFF
--- a/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/remove.py
+++ b/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/remove.py
@@ -16,13 +16,16 @@ from gettext import gettext as _
 from pulp.client.commands.unit import UnitRemoveCommand
 from pulp_puppet.common import constants
 
-class RemoveCommand(UnitRemoveCommand):
-    DESC = _('remove copied or uploaded modules from a repository')
 
-    def __init__(self, context):
+DESC_REMOVE = _('remove copied or uploaded modules from a repository')
+
+
+class RemoveCommand(UnitRemoveCommand):
+
+    def __init__(self, context, name='remove', description=DESC_REMOVE):
         super(RemoveCommand, self).__init__(
             context,
-            name='remove',
-            description=self.DESC,
+            name=name,
+            description=description,
             type_id=constants.TYPE_PUPPET_MODULE,
         )

--- a/pulp_puppet_extensions_admin/test/unit/test_extension_repo.py
+++ b/pulp_puppet_extensions_admin/test/unit/test_extension_repo.py
@@ -15,14 +15,15 @@ from pulp.client.commands.criteria import CriteriaCommand
 from pulp.client.commands import options
 from pulp.client.commands.repo import cudl as pulp_cudl
 import pulp.client.commands.unit
-from pulp.client.extensions.core import TAG_SUCCESS, TAG_REASONS, TAG_DOCUMENT, TAG_TITLE
+from pulp.client.extensions.core import TAG_SUCCESS, TAG_REASONS
 from pulp.common.compat import json
 
 import base_cli
 from pulp_puppet.common import constants
 from pulp_puppet.extensions.admin import pulp_cli as commands
 from pulp_puppet.extensions.admin.repo import cudl
-from pulp_puppet.extensions.admin.repo.remove import RemoveCommand
+from pulp_puppet.extensions.admin.repo.remove import RemoveCommand, DESC_REMOVE
+
 
 class CreatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
 
@@ -342,7 +343,7 @@ class RemovePuppetModulesCommand(base_cli.ExtensionTests):
     def test_defaults(self):
         self.assertTrue(isinstance(self.command, pulp.client.commands.unit.UnitRemoveCommand))
         self.assertEqual('remove', self.command.name)
-        self.assertEqual(RemoveCommand.DESC, self.command.description)
+        self.assertEqual(DESC_REMOVE, self.command.description)
         # uses default remove method
-        self.assertEqual(self.command.method, self.command.remove)
+        self.assertEqual(self.command.method, self.command.run)
 


### PR DESCRIPTION
Corresponds to the changes in: https://github.com/pulp/pulp/pull/407

The APIs into the unit remove command didn't change, so the changes here are largely for consistency with how other commands are defined. I didn't actually need to change anything but by the time that was clear, I had already made these changes.
