### PR TITLE
Changed to display copied modules as part of the copy command

### DIFF
--- a/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/copy_modules.py
+++ b/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/copy_modules.py
@@ -16,15 +16,24 @@ from gettext import gettext as _
 from pulp.client.commands.unit import UnitCopyCommand
 
 from pulp_puppet.common import constants
+from pulp_puppet.extensions.admin.repo import units_display
 
-# -- constants ----------------------------------------------------------------
 
 DESC_COPY = _('copies modules from one repository into another')
 
-# -- commands -----------------------------------------------------------------
+# Number of modules after which this command won't bother printing them all to the screen
+DEFAULT_MODULES_THRESHOLD = 100
+
 
 class PuppetModuleCopyCommand(UnitCopyCommand):
 
-    def __init__(self, context, name='copy', description=DESC_COPY):
+    def __init__(self, context, name='copy', description=DESC_COPY,
+                 module_count_threshold=DEFAULT_MODULES_THRESHOLD):
         UnitCopyCommand.__init__(self, context, name=name, description=description,
                                  method=self.run, type_id=constants.TYPE_PUPPET_MODULE)
+
+        self.module_count_threshold = module_count_threshold
+
+    def succeeded(self, task):
+        copied_modules = task.result  # list of dict containing unit_key and type_id
+        units_display.display_modules(self.prompt, copied_modules, self.module_count_threshold)

--- a/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/units_display.py
+++ b/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/units_display.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+"""
+Methods to handle the rendering of a unit list returned from either the copy
+or remove units commands.
+"""
+
+from gettext import gettext as _
+
+MODULE_ID_TEMPLATE = '%(author)s-%(name)s-%(version)s'
+
+
+def display_modules(prompt, copied_modules, module_count_threshold):
+    if len(copied_modules) == 0:
+        prompt.write(_('No modules matched the given criteria.'), tag='too-few')
+
+    elif len(copied_modules) >= module_count_threshold:
+        prompt.write(_('%s modules were copied.') % len(copied_modules), tag='too-many')
+
+    else:
+        prompt.write(_('Copied Modules:'), tag='just-enough')
+        copied_modules.sort(key=lambda x : x['unit_key']['author'])
+        for m in copied_modules:
+            module_id = MODULE_ID_TEMPLATE % m['unit_key']
+            prompt.write('  %s' % module_id, tag='module')

--- a/pulp_puppet_extensions_admin/test/unit/test_extension_copy.py
+++ b/pulp_puppet_extensions_admin/test/unit/test_extension_copy.py
@@ -89,3 +89,18 @@ class CopyCommandTests(base_cli.ExtensionTests):
             # client-side flag took place
             self.assertEqual(['from-repo-id'], e.extra_data['property_names'])
             self.assertTrue('source_repo_id' not in e.extra_data['property_names'])
+
+    @mock.patch('pulp_puppet.extensions.admin.repo.units_display.display_modules')
+    def test_succeeded(self, mock_display):
+        # Setup
+        fake_modules = 'm'
+        fake_task = mock.MagicMock()
+        fake_task.result = fake_modules
+
+        # Test
+        self.command.succeeded(fake_task)
+
+        # Verify
+        mock_display.assert_called_once_with(self.prompt, fake_modules, self.command.module_count_threshold)
+
+

--- a/pulp_puppet_extensions_admin/test/unit/test_units_display.py
+++ b/pulp_puppet_extensions_admin/test/unit/test_units_display.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+import unittest
+
+import okaara.prompt
+from pulp.client.extensions.core import PulpPrompt
+
+from pulp_puppet.common import constants
+from pulp_puppet.extensions.admin.repo import units_display
+
+
+class UnitsDisplayTests(unittest.TestCase):
+
+    def setUp(self):
+        super(UnitsDisplayTests, self).setUp()
+
+        # Disabling color makes it easier to grep results since the character codes aren't there
+        self.recorder = okaara.prompt.Recorder()
+        self.prompt = PulpPrompt(enable_color=False, output=self.recorder, record_tags=True)
+
+    def test_display_modules_zero_count(self):
+        # Test
+        units_display.display_modules(self.prompt, [], 10)
+
+        # Verify
+        self.assertEqual(['too-few'], self.prompt.get_write_tags())
+
+    def test_display_modules_over_threshold(self):
+        # Test
+        copied_modules = self._generate_copied_modules(10)
+        units_display.display_modules(self.prompt, copied_modules, 5)
+
+        # Verify
+        self.assertEqual(['too-many'], self.prompt.get_write_tags())
+        self.assertTrue('10' in self.recorder.lines[0])
+
+    def test_display_modules_show_modules(self):
+        # Test
+        copied_modules = self._generate_copied_modules(2)
+
+        # Reverse here so we can check the sort takes place in the method
+        copied_modules.sort(key=lambda x : x['unit_key']['author'], reverse=True)
+
+        units_display.display_modules(self.prompt, copied_modules, 10)
+
+        # Verify
+        expected_tags = ['just-enough', 'module', 'module']  # header + one line for each module
+        self.assertEqual(expected_tags, self.prompt.get_write_tags())
+        self.assertTrue('Copied Modules' in self.recorder.lines[0])
+
+        # Verify the sorting was done
+        self.assertTrue('0' in self.recorder.lines[1])
+        self.assertTrue('1' in self.recorder.lines[2])
+
+    def _generate_copied_modules(self, count):
+        """
+        Returns a list of the given size representing modules as they would be handed to
+        the display method.
+        """
+        modules = []
+        for i in range(0, count):
+            unit_key = {
+                'author' : 'author-%s' % i,
+                'name' : 'name-%s' % i,
+                'version' : 'version-%s' % i,
+            }
+            modules.append({'type_id' : constants.TYPE_PUPPET_MODULE,
+                            'unit_key' : unit_key})
+
+        return modules

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/copier.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/copier.py
@@ -30,3 +30,5 @@ def copy_units(import_conduit, units):
     # Associate to the new repository
     for u in units:
         import_conduit.associate_unit(u)
+
+    return units

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/importer.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/importer.py
@@ -57,7 +57,7 @@ class PuppetModuleImporter(Importer):
 
     def import_units(self, source_repo, dest_repo, import_conduit, config,
                      units=None):
-        copier.copy_units(import_conduit, units)
+        return copier.copy_units(import_conduit, units)
 
     def upload_unit(self, repo, type_id, unit_key, metadata, file_path, conduit,
                     config):

--- a/pulp_puppet_plugins/test/unit/test_importer_copier.py
+++ b/pulp_puppet_plugins/test/unit/test_importer_copier.py
@@ -28,9 +28,10 @@ class CopierTests(unittest.TestCase):
         conduit.get_source_units.return_value = all_source_units
 
         # Test
-        copier.copy_units(conduit, None)
+        returned = copier.copy_units(conduit, None)
 
         # Verify
+        self.assertEqual(returned, all_source_units)
         self.assertEqual(1, conduit.get_source_units.call_count)
         call_args = conduit.get_source_units.call_args
         self.assertTrue('criteria' in call_args[1])


### PR DESCRIPTION
Corresponds to: https://github.com/pulp/pulp/pull/415

The approach here was nearly identical in concept to the one in pulp_rpm, so I'll just copy the notes from that PR:

There was already a hook in PollingCommand to handle the task end result. This was implemented to use a separate module for rendering the units. That rendering is kept separate because my next round of changes will be to the unassociate units flow to return the units as well, so that rendering is going to be needed for that command as well.
