### PR TITLE
975103 - Removing metadata 'types' field from default rendering of puppe...

### DIFF
--- a/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/modules.py
+++ b/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/modules.py
@@ -48,7 +48,9 @@ class ModulesCommand(DisplayUnitAssociationsCommand):
         order = []
 
         if not kwargs.get(self.ASSOCIATION_FLAG.keyword):
-            # Only display the module metadata, not the association
+            # Remove types from the metadata as it can be very long by default
+            # and only display the module metadata, not the association
+            map(lambda x : x['metadata'].pop('types', None), modules)
             modules = [m['metadata'] for m in modules]
             # Make sure the key info is at the top; the rest can be alpha
             order = ['name', 'version', 'author']


### PR DESCRIPTION
...t modules and adding it only when --details flag is specified

https://bugzilla.redhat.com/show_bug.cgi?id=975103
