### PR TITLE
moving the extend_path call to the "pulp_puppet" module, where it is act...

### DIFF
--- a/pulp_puppet_tools/pulp_puppet/__init__.py
+++ b/pulp_puppet_tools/pulp_puppet/__init__.py
@@ -1,1 +1,3 @@
+from pkgutil import extend_path
 
+__path__ = extend_path(__path__, __name__)

--- a/pulp_puppet_tools/pulp_puppet/tools/__init__.py
+++ b/pulp_puppet_tools/pulp_puppet/tools/__init__.py
@@ -1,3 +1,0 @@
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
...ually needed.

Without it at this level, the pulp_puppet_tools package was clobbering the pulp_puppet namespace.
