### PR TITLE
1051700 - Don't build admin extensions, plugins, or tools on EL 5.

### DIFF
--- a/pulp-puppet.spec
+++ b/pulp-puppet.spec
@@ -79,6 +79,9 @@ popd
 
 %install
 rm -rf %{buildroot}
+
+mkdir -p %{buildroot}/%{_sysconfdir}/pulp/
+
 pushd pulp_puppet_common
 %{__python} setup.py install -O1 --skip-build --root %{buildroot}
 popd


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1051700
