### PR TITLE
1103311 - Extract any unit_key fields from metadata if None

### DIFF
--- a/pulp_puppet_common/pulp_puppet/common/model.py
+++ b/pulp_puppet_common/pulp_puppet/common/model.py
@@ -109,6 +109,26 @@ class Module(object):
 
         return cls.from_dict(unit_as_dict)
 
+    @classmethod
+    def from_json(cls, module_json):
+        """
+        Converts a module's metadata.json to a Module representation.
+
+        :param module_json: dict with values from metadata.json
+        :type  module_json: dict
+
+        :return: object representation of the given module
+        :rtype:  Module
+        """
+        # The unique identifier fields are all required and should be present
+        author, name = module_json.get('name').split("-", 1)
+        version = module_json.get('version')
+
+        module = cls(name, version, author)
+        module.update_from_dict(module_json)
+
+        return module
+
     @staticmethod
     def generate_unit_key(name, version, author):
         """

--- a/pulp_puppet_common/test/unit/test_common_model.py
+++ b/pulp_puppet_common/test/unit/test_common_model.py
@@ -163,6 +163,20 @@ class ModuleTests(unittest.TestCase):
         # Verify
         self.assert_valid_module(module)
 
+    def test_from_json(self):
+        # Setup
+        data = json.loads(VALID_MODULE_METADATA_JSON)
+
+        # Test
+        module = Module.from_json(data)
+
+        # Verify
+        self.assertEqual(module.name, "valid")
+        self.assertEqual(module.author, "jdob")
+
+        module.name = "jdob-valid" # rename the module to use the assert
+        self.assert_valid_module(module)
+
     def assert_valid_module(self, module):
         self.assertEqual(module.name, 'jdob-valid')
         self.assertEqual(module.version, '1.0.0')

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -314,7 +314,8 @@ class SynchronizeWithPuppetForge(object):
                 shutil.copy(downloaded_filename, unit.storage_path)
 
             # Extract the extra metadata into the module
-            metadata.extract_metadata(module, unit.storage_path, self.repo.working_dir)
+            metadata_json = metadata.extract_metadata(unit.storage_path, self.repo.working_dir, module)
+            module = Module.from_json(metadata_json)
 
             # Update the unit with the extracted metadata
             unit.metadata = module.unit_metadata()

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
@@ -44,13 +44,18 @@ def handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path, conduit):
     if type_id != constants.TYPE_PUPPET_MODULE:
         raise NotImplementedError()
 
-    # Create a module out of the uploaded metadata
-    combined = copy.copy(unit_key)
-    combined.update(metadata)
-    module = Module.from_dict(combined)
+    # Create a module with unit_key if supplied
+    initial_module = None
+    if unit_key:
+        initial_module = Module.from_dict(unit_key)
 
     # Extract the metadata from the module
-    metadata_parser.extract_metadata(module, file_path, repo.working_dir)
+    extracted_data = metadata_parser.extract_metadata(file_path, repo.working_dir, initial_module)
+    checksum = metadata_parser.calculate_checksum(file_path)
+
+    # Create a module from the metadata
+    module = Module.from_json(extracted_data)
+    module.checksum = checksum
 
     # Create the Pulp unit
     type_id = constants.TYPE_PUPPET_MODULE

--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_upload.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_upload.py
@@ -73,6 +73,24 @@ class UploadTests(unittest.TestCase):
         self.assertTrue('summary' in report)
         self.assertTrue('details' in report)
 
+    def test_handle_uploaded_unit_with_no_data(self):
+        # Setup
+        initialized_unit = mock.MagicMock()
+        initialized_unit.storage_path = self.dest_dir
+        self.conduit.init_unit.return_value = initialized_unit
+
+        # Test
+        report = upload.handle_uploaded_unit(self.repo, constants.TYPE_PUPPET_MODULE, {},
+                                             {}, self.source_file, self.conduit)
+
+        # Verify
+        self.assertTrue(os.path.exists(self.dest_file))
+
+        self.assertEqual(1, self.conduit.init_unit.call_count)
+        self.assertEqual(1, self.conduit.save_unit.call_count)
+
+        self.assertTrue(report['success_flag'])
+
     def test_handle_uploaded_unit_bad_type(self):
         self.assertRaises(NotImplementedError, upload.handle_uploaded_unit, self.repo, 'foo',
                           None, None, None, None)


### PR DESCRIPTION
If no unit_key metadata is passed in for uploaded puppet modules, just use the
module metadata to populate name, author, and version.

https://bugzilla.redhat.com/show_bug.cgi?id=1103311

**TODO**
- [x] Add tests
- [x] Address any feedback
