### PR TITLE
1149894 - Has tempdir selection for installdistributor use get_parent_directory from platform

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -309,7 +309,7 @@ class PuppetModuleInstallDistributor(Distributor):
                 pass  # ignored
             else:
                 raise e
-        return tempfile.mkdtemp(dir=basedir)
+        return tempfile.mkdtemp(prefix='pulp', dir=basedir)
 
     @staticmethod
     def _move_to_destination_directory(source, destination):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1149894

This is the pulp_puppet PR that corresponds with [PR 1192](https://github.com/pulp/pulp/pull/1192) against pulp/pulp. This PR depends on the other one so it needs to be tested with PR 1192. They need to be merged together.

This change does not have unit tests because the entire installdistributor does not have unit tests and that is a bigger, different problem. I have filed the lack of unit tests as its own [BZ 1150136](https://bugzilla.redhat.com/show_bug.cgi?id=1150136).
