### PR TITLE
1153072 - do not delete /var/www/pulp_puppet on upgrade

### DIFF
--- a/docs/user-guide/release-notes/2.5.x.rst
+++ b/docs/user-guide/release-notes/2.5.x.rst
@@ -1,0 +1,18 @@
+======================
+Pulp 2.5 Release Notes
+======================
+
+Pulp 2.5.0
+==========
+
+The 2.5.0 release of ``pulp-puppet`` is a minor update release with bugfixes
+and one new feature. The ``--skip-dep`` and ``--modulepath`` flags are now
+supported during install and update operations.
+
+Users upgrading from 2.3.x or earlier will need to manually delete the
+``/var/www/pulp_puppet`` directory after upgrading. This is the old location
+for puppet module publishing in Pulp 2.3 but is no longer used. The directory
+should be empty after the migration is complete.
+
+You can see the list of bugs fixed
+`here <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=puppet-support&list_id=2768100&product=Pulp&query_format=advanced&target_release=2.5.0>`_.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.5.x
    2.4.x
    2.3.x
    2.2.x

--- a/pulp_puppet_plugins/pulp_puppet/plugins/migrations/0002_puppet_publishing_directory_change.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/migrations/0002_puppet_publishing_directory_change.py
@@ -28,24 +28,19 @@ def migrate(*args, **kwargs):
     Move files from old publish directories to the new location.
     """
     old_puppet_publish_dir = os.path.join(OLD_PUBLISH_ROOT_DIR, OLD_PUPPET_PUBLISH_DIR_NAME)
+    new_puppet_publish_dir = os.path.join(NEW_PUBLISH_ROOT_DIR, NEW_PUPPET_PUBLISH_DIR_NAME)
     if os.path.exists(old_puppet_publish_dir) and os.listdir(old_puppet_publish_dir):
-        # Copy contents of '/var/www/pulp_puppet' to '/var/lib/pulp/published/puppet'
-        move_directory_contents_and_rename(old_puppet_publish_dir,
-                                           NEW_PUBLISH_ROOT_DIR,
-                                           OLD_PUPPET_PUBLISH_DIR_NAME,
-                                           NEW_PUPPET_PUBLISH_DIR_NAME)
+        # Move contents of '/var/www/pulp_puppet' into '/var/lib/pulp/published/puppet'
+        move_directory_contents(old_puppet_publish_dir, new_puppet_publish_dir)
         _log.info("Migrated published puppet repositories to the new location")
 
 
-def move_directory_contents_and_rename(src_dir, dest_dir, old_dir_name, new_dir_name):
+def move_directory_contents(src_dir, dest_dir):
     """
-    Move directory src_dir to dest_dir and rename it to new_dir_name.
+    Move everything in src_dir to dest_dir
     """
-    shutil.move(src_dir, dest_dir)
-    new_puppet_publish_dir = os.path.join(dest_dir, new_dir_name)
-    if os.path.exists(new_puppet_publish_dir):
-        os.rmdir(new_puppet_publish_dir)
-
-    copied_pulp_puppet_directory = os.path.join(dest_dir, old_dir_name)
-    os.rename(copied_pulp_puppet_directory, new_puppet_publish_dir)
-
+    # perform the move. /var/lib/pulp/published/puppet already exists so we
+    # need to move like this (i.e, we can't use shutil.copytree). This should
+    # leave an empty /var/www/pulp_puppet dir.
+    for entry in os.listdir(src_dir):
+        shutil.move(os.path.join(src_dir, entry), os.path.join(dest_dir, entry))

--- a/pulp_puppet_plugins/test/unit/plugins/migrations/test_0002_puppet_publishing_directory_change.py
+++ b/pulp_puppet_plugins/test/unit/plugins/migrations/test_0002_puppet_publishing_directory_change.py
@@ -28,7 +28,7 @@ class Test0002PuppetPublishingDirectoryChange(unittest.TestCase):
     """
 
     @patch('pulp_puppet.plugins.migrations.0002_puppet_publishing_directory_change.'
-           'move_directory_contents_and_rename')
+           'move_directory_contents')
     @patch('os.path.exists')
     @patch('os.listdir')
     def test_migration(self, mock_listdir, mock_path_exists, mock_move_directory):
@@ -38,7 +38,7 @@ class Test0002PuppetPublishingDirectoryChange(unittest.TestCase):
         mock_listdir.assert_called_once_with('/var/www/pulp_puppet')
         mock_path_exists.assert_called_once_with('/var/www/pulp_puppet')
 
-    def test_move_directory_contents_and_rename(self):
+    def test_move_directory_contents(self):
         test_old_publish_dir = tempfile.mkdtemp(prefix='test_0002_migration_old')
         old_http_publish_dir = os.path.join(test_old_publish_dir, 'http', 'repos')
         old_https_publish_dir = os.path.join(test_old_publish_dir, 'https', 'repos')
@@ -46,17 +46,27 @@ class Test0002PuppetPublishingDirectoryChange(unittest.TestCase):
         os.makedirs(old_https_publish_dir)
 
         test_new_publish_dir = tempfile.mkdtemp(prefix='test_0002_migration_new')
-        new_http_publish_dir = os.path.join(test_new_publish_dir, 'puppet', 'http', 'repos')
-        new_https_publish_dir = os.path.join(test_new_publish_dir, 'puppet', 'https', 'repos')
+        test_new_publish_puppet_dir = os.path.join(test_new_publish_dir, 'puppet')
+        # on a real system, this dir is created by the rpm
+        os.mkdir(test_new_publish_puppet_dir)
+
+        new_http_publish_dir = os.path.join(test_new_publish_puppet_dir, 'http', 'repos')
+        new_https_publish_dir = os.path.join(test_new_publish_puppet_dir, 'https', 'repos')
+        # put a file in the top-level dir to ensure it gets copied over too.
+        # It is not typical to have a file there but we should move it over
+        # just in case.
+        open(os.path.join(test_old_publish_dir, 'some_file'), 'w').close()
 
         migration = _import_all_the_way('pulp_puppet.plugins.migrations.0002_puppet_'
                                         'publishing_directory_change')
-        migration.move_directory_contents_and_rename(test_old_publish_dir,
-                                                     test_new_publish_dir,
-                                                     os.path.basename(test_old_publish_dir),
-                                                     'puppet')
+
+        migration.move_directory_contents(test_old_publish_dir, test_new_publish_puppet_dir)
 
         self.assertTrue(os.path.exists(new_http_publish_dir))
         self.assertTrue(os.path.exists(new_https_publish_dir))
-        self.assertFalse(os.path.exists(test_old_publish_dir))
-
+        self.assertTrue(os.path.exists(os.path.join(test_new_publish_puppet_dir, 'some_file')))
+        # bz 1153072 - user needs to clear this dir manually
+        self.assertTrue(os.path.exists(test_old_publish_dir))
+        for (root, files, dirs) in os.walk(test_old_publish_dir):
+            self.assertTrue(files == [])
+            self.assertTrue(dirs == [])


### PR DESCRIPTION
Previously, the upgrade script would attempt to delete `/var/www/pulp_puppet`
as part of the upgrade procedure. This does not work since the upgrade runs as
apache user and not root.

Instead, simply copy the contents of the directory to the new location and add
a release note for users to remove the directory on their own.

Also, the migration script had an unrelated bug where **os.rmdir()** was being
used instead of **shutil.rmtree()**. This has been corrected.
