### PR TITLE
1009429 - Don't verify FS permissions with httpd.

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -73,13 +73,6 @@ class PuppetModuleInstallDistributor(Distributor):
             return True, None
         if not os.path.isabs(path):
             return False, _('install path is not absolute')
-        if os.path.exists(path):
-            if not os.path.isdir(path):
-                return False, _('install path exists but is not a directory')
-            # we need X to get directory listings
-            if not os.access(path, os.R_OK|os.W_OK|os.X_OK):
-                return False, _('the current user does not have permission to read '
-                                'and write files in the destination directory')
         return True, None
 
     def publish_repo(self, repo, publish_conduit, config):

--- a/pulp_puppet_plugins/test/unit/test_install_distributor.py
+++ b/pulp_puppet_plugins/test/unit/test_install_distributor.py
@@ -1,16 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 from cStringIO import StringIO
 import os
 import tarfile
@@ -53,23 +40,6 @@ class TestValidateConfig(unittest.TestCase):
 
     def test_relative_path(self):
         config = PluginCallConfiguration({}, {constants.CONFIG_INSTALL_PATH: 'a/b/c'})
-
-        result, message = self.distributor.validate_config(self.repo, config, [])
-
-        self.assertFalse(result)
-        self.assertTrue(len(message) > 0)
-
-    def test_path_is_not_dir(self):
-        config = PluginCallConfiguration({}, {constants.CONFIG_INSTALL_PATH: __file__})
-
-        result, message = self.distributor.validate_config(self.repo, config, [])
-
-        self.assertFalse(result)
-        self.assertTrue(len(message) > 0)
-
-    def test_without_permission(self):
-        # you're not running your tests as root, RIGHT?
-        config = PluginCallConfiguration({}, {constants.CONFIG_INSTALL_PATH: '/root'})
 
         result, message = self.distributor.validate_config(self.repo, config, [])
 


### PR DESCRIPTION
The install distributor used to check FS permissions with httpd, but
this caused a failure with our more restrictive selinux policy in 2.5.0
since httpd does not have permission to write to /etc/puppet.

https://bugzilla.redhat.com/show_bug.cgi?id=1009429
