### PR TITLE
1146916 - pulp-puppet-module-builder now builds modules without init.pp files

### DIFF
--- a/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
+++ b/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
@@ -396,12 +396,11 @@ class TestBuilder(TestCase):
     @patch('pulp_puppet.tools.puppet_module_builder.shell')
     def test_find_modules(self, mock_shell):
         mock_shell.return_value = (0, """
-            module_1/tests/init.pp
-            module_1/manifests/init.pp
-            nested/module_2/tests/init.pp
-            nested/module_2/manifests/init.pp
-            module_3/pkg/module_3/manifests/init.pp
-            nothing/init.pp
+            module_1/Modulefile
+            module_1/metadata.json
+            nested/module_2/Modulefile
+            nested/module_3/metadata.json
+            nested/module_3/pkg/module_3/metadata.json
             """)
 
         # test
@@ -409,10 +408,8 @@ class TestBuilder(TestCase):
         modules = builder.find_modules()
 
         # validation
-
-        mock_shell.assert_called_with('find . -name init.pp')
-
-        self.assertEqual(sorted(list(modules)), sorted(['module_1', 'nested/module_2']))
+        self.assertEquals(2, mock_shell.call_count)
+        self.assertEqual(sorted(list(modules)), sorted(['module_1', 'nested/module_2', 'nested/module_3']))
 
     @patch('pulp_puppet.tools.puppet_module_builder.shell')
     def test_git_checkout_branch(self, mock_shell):


### PR DESCRIPTION
This addresses both of the following bugs: 
- https://bugzilla.redhat.com/show_bug.cgi?id=1146916
- https://bugzilla.redhat.com/show_bug.cgi?id=1146834

The tool will now attempt to build a module from any directory containing a `Modulefile` (the old metadata file) or a `metadata.json`. The one exception is if the module is in a `pkg`  directory(e.g. `puppetlabs-mysql/pkg/puppetlabs-mysql/metadata.json`), which is created when `puppet module build puppetlabs-mysql` is run
