### PR TITLE
1184187 - Causes all tests to use pulp_unittest

### DIFF
--- a/pulp_puppet_plugins/test/unit/test_forge_api.py
+++ b/pulp_puppet_plugins/test/unit/test_forge_api.py
@@ -15,10 +15,12 @@ import json
 import unittest
 
 import mock
+from pulp.server.db.connection import initialize
 import web
 
 from pulp_puppet.forge import api
 
+initialize(name='pulp_unittest')
 
 class TestAppPre33(unittest.TestCase):
     app = api.pre_33_app


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1184187

**The Problem**
Line 21 causes a cascading import which executes db.connection.initialize(). That method will initialize the database based on server.conf. Mongoengine then replaces the 'default' database used going forward with the server.conf production database. Tests drop database collections which causes the symptom of BZ 1184187.

**The Solution**
By calling initialize(name='pulp_unittest') after the import it will switch the DB back to the unittest. I could not see any side effects from having api initialize the DB to the production database and immediately after initialize it back to the test database immediately after.

**This is a quick fix**
This change does not come with unittests because a more comprehensive fix is being planned to have only entry points call initialize. All calls to db.connection.initialize() will likely be removed with that change.
