### PR TITLE
The install-distributor now cleans up (deletes) modules on removal from a repo

### DIFF
--- a/docs/tech-reference/plugin_conf.rst
+++ b/docs/tech-reference/plugin_conf.rst
@@ -92,6 +92,9 @@ This distributor starts by deleting every directory it finds in the
 ``install_path``, and then it extracts each module in the repository to that
 directory.
 
+When this distributor gets removed from a repository, such as when the repository
+gets deleted, all directories found in ``install_path`` will be deleted.
+
 .. warning:: This distributor deletes all directories found in the ``install_path``!
 
 ``install_path``

--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -159,6 +159,21 @@ class PuppetModuleInstallDistributor(Distributor):
         else:
             return publish_conduit.build_success_report('success', self.detail_report.report)
 
+    def distributor_removed(self, repo, config):
+        """
+        Removed installed modules from the environment this is configured to use.
+
+        :param repo:    metadata describing the repository
+        :type  repo:    pulp.plugins.model.Repository
+        :param config:  plugin configuration
+        :type  config:  pulp.plugins.config.PluginCallConfiguration
+        """
+        destination = config.get(constants.CONFIG_INSTALL_PATH)
+        if destination:
+            _LOGGER.info(_('removing installed modules from environment at %(directory)s' %
+                           {'directory': destination}))
+            self._clear_destination_directory(destination)
+
     @staticmethod
     def _find_duplicate_names(units):
         """

--- a/pulp_puppet_plugins/test/unit/test_install_distributor.py
+++ b/pulp_puppet_plugins/test/unit/test_install_distributor.py
@@ -567,3 +567,23 @@ class TestEnsureDestinationDir(unittest.TestCase):
         path = 'path-123'
         self.distributor._ensure_destination_dir(path)
         fake_mkdir.assert_called_once_with(path)
+
+
+class TestDistributorRemoved(unittest.TestCase):
+    def setUp(self):
+        self.distributor = installdistributor.PuppetModuleInstallDistributor()
+        self.repo = Repository('repo1', '', '')
+        self.path = '/a/b/c/'
+        self.config = PluginCallConfiguration({}, {constants.CONFIG_INSTALL_PATH: self.path})
+
+    def test_calls_clear_dest(self):
+        with mock.patch.object(self.distributor, '_clear_destination_directory') as mock_clear:
+            self.distributor.distributor_removed(self.repo, self.config)
+
+        mock_clear.assert_called_once_with(self.path)
+
+    def test_without_configured_path(self):
+        with mock.patch.object(self.distributor, '_clear_destination_directory') as mock_clear:
+            self.distributor.distributor_removed(self.repo, PluginCallConfiguration({}, {}))
+
+        self.assertEqual(mock_clear.call_count, 0)


### PR DESCRIPTION
When this distributor gets removed from a repository, such as when the repository
gets deleted, all modules in its install path will be deleted.

closes #732

https://pulp.plan.io/issues/732