### PR TITLE
Adding release notes for 2.7.0

### DIFF
--- a/docs/tech-reference/plugin_conf.rst
+++ b/docs/tech-reference/plugin_conf.rst
@@ -77,6 +77,8 @@ at one FQDN.
  Boolean indicating if the repository should be served over HTTPS. Defaults to ``False``.
 
 
+.. _install-distributor:
+
 Install Distributor
 -------------------
 

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -9,5 +9,6 @@ New Features
 ------------
 
 - Support for using the Puppet Forge v3 API for installing modules
+- The :ref:`install-distributor` cleans up published modules on repo delete
 
 You can see the :fixedbugs:`list of bugs fixed<2.7.0>`.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.7.x
    2.6.x
    2.5.x
    2.4.x


### PR DESCRIPTION
This goes with #170 , but is in a separate PR because a major user wants to cherry-pick the code changes in that PR onto pulp 2.6.0. It was easier to put the release notes in a separate PR, so the original can apply cleanly to 2.6.0.