### PR TITLE
Updates metadata.json search to look in first top-level folder

### DIFF
--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_metadata.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_metadata.py
@@ -1,16 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 import os
 import shutil
 import tempfile
@@ -23,11 +10,8 @@ from pulp.server.exceptions import InvalidValue
 from pulp_puppet.common.model import Module
 from pulp_puppet.plugins.importers import metadata
 
-# -- constants ----------------------------------------------------------------
 
 DATA_DIR = os.path.abspath(os.path.dirname(__file__)) + '/../../../data'
-
-# -- test cases ---------------------------------------------------------------
 
 
 class SuccessfulMetadataTests(unittest.TestCase):


### PR DESCRIPTION
The implementation was using a depth-first-search which did not
traverse in the same order on all platforms. Some Puppet modules
contain other modules as dependencies, and the DFS implementation
could incorrectly find the wrong one. This uses a very dumb
approach which looks for metadata.json in the top level folder
of the the tar.gz uploaded Puppet module. This is based on the
Puppet packaging guidelines [0].

[0]:  https://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html#module-fundamentals

https://pulp.plan.io/issues/890
closes #890