### PR TITLE
Removed generation of unit key based on file name of puppet module

### DIFF
--- a/docs/tech-reference/type.rst
+++ b/docs/tech-reference/type.rst
@@ -32,7 +32,7 @@ Metadata
  and a key ``version_requirement`` which describes what versions are acceptable
  to satisfy this dependency. This is an empty list if there are no dependencies.
  The format for this value is described in detail in Puppet Labs' own
- `documentation <http://docs.puppetlabs.com/puppet/2.7/reference/modules_publishing.html>`_.
+ `documentation <http://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#write-a-metadatajson-file>`_.
 
 ``description``
  Longer description of the module.

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -16,9 +16,8 @@ in order to implement an API compatible with Puppet Forge. We don't like
 taking that namespace, but it was the only way to support the use of Puppet
 Labs' command line tool against a Pulp server.
 
-Consumers must have Puppet 2.7.14 to 3.2.4 installed, and we recommend getting packages
-directly from `Puppet Labs <http://puppetlabs.com>`_.  Pulp is not compatible with Puppet
-3.3.x.
+Consumers must have Puppet 2.7.14 to 3.4.3 installed, and we recommend getting packages
+directly from `Puppet Labs <http://puppetlabs.com>`_.
 
 Please see the `Pulp User Guide`_ for other prerequisites including repository
 setup.

--- a/docs/user-guide/introduction.rst
+++ b/docs/user-guide/introduction.rst
@@ -11,3 +11,12 @@ Another common use case is to copy synced modules into a custom repository and a
 additional modules by uploading them directly. This allows you to test new modules
 or new versions of existing modules and then easily promote them into a production
 repository.
+
+Puppet modules must adhere to the Puppet `3.6+ metadata guidelines
+<https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#publishing-modules-on-the-puppet-forge>`_,
+which require a valid `metadata.json` file to be present in the puppet module. Also, each tag.gz
+file must contain only one Puppet module inside it. Extra directories or Puppet modules can cause
+unexpected behavior.
+
+Consumers must have Puppet 2.7.14 to 3.4.3 installed, and we recommend getting the Puppet client
+packages directly from `Puppet Labs <http://puppetlabs.com>`_.

--- a/docs/user-guide/quick-start.rst
+++ b/docs/user-guide/quick-start.rst
@@ -253,6 +253,51 @@ a result of the above sync.
   Result:      Incomplete
   Task Id:     54459b2f-6ed9-4918-94c9-63e2b3370554
 
+Upload a module
+---------------
+
+Assuming we have a repository with repo-id `repo1` we can upload an archive containing a Puppet
+module. This operation does not auto publish the repository.
+
+ ::
+
+   $ pulp-admin puppet repo uploads upload --file puppetlabs-apache-1.4.0.tar.gz --repo-id repo1
+     +----------------------------------------------------------------------+
+                                   Unit Upload
+     +----------------------------------------------------------------------+
+
+     Extracting necessary metadata for each request...
+     [==================================================] 100%
+     Analyzing: puppetlabs-apache-1.4.0.tar.gz
+     ... completed
+
+     Creating upload requests on the server...
+     [==================================================] 100%
+     Initializing: puppetlabs-apache-1.4.0.tar.gz
+     ... completed
+
+     Starting upload of selected units. If this process is stopped through ctrl+c,
+     the uploads will be paused and may be resumed later using the resume command or
+     cancelled entirely using the cancel command.
+
+     Uploading: puppetlabs-apache-1.4.0.tar.gz
+     [==================================================] 100%
+     147426/147426 bytes
+     ... completed
+
+     Importing into the repository...
+     This command may be exited via ctrl+c without affecting the request.
+
+
+     [\]
+     Running...
+
+     Task Succeeded
+
+
+     Deleting the upload request...
+     ... completed
+
 Publish a Repository
 --------------------
 

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -11,4 +11,14 @@ New Features
 - Support for using the Puppet Forge v3 API for installing modules
 - The :ref:`install-distributor` cleans up published modules on repo delete
 
+API Changes
+-----------
+
+- The `unit_key` parameter is ignored by the API when uploading puppet modules. The unit key is
+  always determined through inspection of metadata.json in the top level directory. The parameter
+  `unit key` is still required by the Pulp platform, but its value is ignored for Puppet content.
+
+Bugs Fixed
+----------
+
 You can see the :fixedbugs:`list of bugs fixed<2.7.0>`.

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -61,3 +61,23 @@ install`` tool is able to verify the server's SSL certificate with a trusted CA.
 Details on how to install a new trusted CA are outside the scope of this
 document.
 
+Missing metadata.json file
+--------------------------
+
+If uploading a puppet module results in `MissingModuleFile` error, one possible problem is that the
+tar.gz file being uploaded does not contain `metadata.json` file. Another possible problem is
+presence of more than one directory (Puppet module) inside the archive.
+
+Solution
+^^^^^^^^
+
+Modules must adhere to the `3.6+ metadata guidlines
+<https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#publishing-modules-on-the-puppet-forge>`_.
+Also ensure that an uploaded archive contains only one Puppet module.
+
+Incorrect Puppet module metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If metadata for a Puppet module in a Pulp repository doesn't match metadata in the `metadata.json`
+module, the tar.gz archive contains multiple Puppet modules. Ensure that an
+uploaded tar.gz file contains only one Puppet module.

--- a/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/upload.py
+++ b/pulp_puppet_extensions_admin/pulp_puppet/extensions/admin/repo/upload.py
@@ -40,11 +40,8 @@ class UploadModuleCommand(upload_commands.UploadCommand):
         self.add_option(option_file)
 
     def generate_unit_key(self, filename, **kwargs):
-        root_filename = os.path.basename(filename)
-        root_filename = root_filename[:-len('.tar.gz')]
-        author, name, version = root_filename.split('-', 2)
-        unit_key = Module.generate_unit_key(name, version, author)
-        return unit_key
+        # Need to return empty string and not None because CLI expects a string
+        return ""
 
     def determine_type_id(self, filename, **kwargs):
         return constants.TYPE_PUPPET_MODULE

--- a/pulp_puppet_extensions_admin/test/unit/test_extension_upload.py
+++ b/pulp_puppet_extensions_admin/test/unit/test_extension_upload.py
@@ -40,17 +40,7 @@ class UploadModuleCommandTests(base_cli.ExtensionTests):
         key = self.command.generate_unit_key(self.filename)
 
         # Verify
-        expected_key = Module.generate_unit_key('valid', '1.0.0', 'jdob')
-        self.assertEqual(key, expected_key)
-
-    def test_generate_unit_key_complex_version(self):
-        filename = os.path.join(MODULES_DIR, 'jdob-valid-1.0.0-rc1.tar.gz')
-
-        # Test
-        key = self.command.generate_unit_key(filename)
-
-        # Verify
-        expected_key = Module.generate_unit_key('valid', '1.0.0-rc1', 'jdob')
+        expected_key = ""
         self.assertEqual(key, expected_key)
 
     def test_determine_type_id(self):

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -306,7 +306,7 @@ class SynchronizeWithPuppetForge(object):
                 shutil.copy(downloaded_filename, unit.storage_path)
 
             # Extract the extra metadata into the module
-            metadata_json = metadata_module.extract_metadata(unit.storage_path, self.repo.working_dir, module)
+            metadata_json = metadata_module.extract_metadata(unit.storage_path, self.repo.working_dir)
             module = Module.from_json(metadata_json)
 
             # Update the unit with the extracted metadata

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
@@ -44,13 +44,8 @@ def handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path, conduit):
     if type_id != constants.TYPE_PUPPET_MODULE:
         raise NotImplementedError()
 
-    # Create a module with unit_key if supplied
-    initial_module = None
-    if unit_key:
-        initial_module = Module.from_dict(unit_key)
-
     # Extract the metadata from the module
-    extracted_data = metadata_parser.extract_metadata(file_path, repo.working_dir, initial_module)
+    extracted_data = metadata_parser.extract_metadata(file_path, repo.working_dir)
     checksum = metadata_parser.calculate_checksum(file_path)
 
     # Create a module from the metadata

--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_metadata.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_metadata.py
@@ -35,7 +35,7 @@ class SuccessfulMetadataTests(unittest.TestCase):
         filename = os.path.join(self.module_dir, self.module.filename())
 
         # Test
-        metadata_json = metadata.extract_metadata(filename, self.tmp_dir, self.module)
+        metadata_json = metadata.extract_metadata(filename, self.tmp_dir)
         self.module = Module.from_json(metadata_json)
 
         # Verify
@@ -55,7 +55,7 @@ class SuccessfulMetadataTests(unittest.TestCase):
         mkdtemp.return_value = extraction_dir
 
         # Test
-        metadata_json = metadata.extract_metadata(filename, self.tmp_dir, self.module)
+        metadata_json = metadata.extract_metadata(filename, self.tmp_dir)
         self.module.update_from_dict(metadata_json)
 
         # Verify - contains the same module as jdob-valid-1.0.0, so this is safe
@@ -144,7 +144,7 @@ class NegativeMetadataTests(unittest.TestCase):
 
         # Test
         try:
-            metadata.extract_metadata(filename, self.tmp_dir, self.module)
+            metadata.extract_metadata(filename, self.tmp_dir)
             self.fail()
         except metadata.ExtractionException, e:
             self.assertEqual(e.module_filename, filename)
@@ -158,7 +158,7 @@ class NegativeMetadataTests(unittest.TestCase):
 
         # Test
         try:
-            metadata._extract_non_standard_json(filename, self.tmp_dir)
+            metadata._extract_json(filename, self.tmp_dir)
             self.fail()
         except metadata.ExtractionException, e:
             self.assertEqual(e.module_filename, filename)


### PR DESCRIPTION
This patch ensures that pulp-admin submits an empty string when making a request
to upload a puppet module. The unit key is generated on the server based on the
content of metadata.json found in the top level directory of a puppet module.

closes #920