### PR TITLE
Repo delete now causes install distributor to delete the environment's directory

### DIFF
--- a/docs/tech-reference/plugin_conf.rst
+++ b/docs/tech-reference/plugin_conf.rst
@@ -98,14 +98,15 @@ This distributor performs these operations in the following order:
  5. Removes the temporary directory.
 
 When this distributor gets removed from a repository, such as when the repository
-gets deleted, all directories found in ``install_path`` will be deleted.
+gets deleted, the ``install_path`` and everything in it will be deleted.
 
-.. warning:: This distributor deletes all directories found in the ``install_path``!
+.. warning:: This distributor deletes everything in the ``install_path``!
 
 ``install_path``
  This is a full path to the directory where modules should be installed. It is the user's
  responsibility to ensure that Pulp can write to this directory. The web server user (for example,
  ``apache``) must be granted filesystem permissions to write to this path and the parent directory.
+ If the directory does not exist, it will be created.
  Additionally, the system SELinux policy must permit Pulp to write to this directory. Pulp's SELinux
  policy includes a ``pulp_manage_puppet`` boolean that allows Pulp to write to paths that have the
  ``puppet_etc_t`` label. You must ensure that the ``install_path`` and its parent directory have this

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -9,7 +9,7 @@ New Features
 ------------
 
 - Support for using the Puppet Forge v3 API for installing modules
-- The :ref:`install-distributor` cleans up published modules on repo delete
+- The :ref:`install-distributor` removes the environment directory on repo delete
 
 API Changes
 -----------

--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -161,7 +161,7 @@ class PuppetModuleInstallDistributor(Distributor):
 
     def distributor_removed(self, repo, config):
         """
-        Removed installed modules from the environment this is configured to use.
+        Remove the environment that is configured for use.
 
         :param repo:    metadata describing the repository
         :type  repo:    pulp.plugins.model.Repository
@@ -172,7 +172,11 @@ class PuppetModuleInstallDistributor(Distributor):
         if destination:
             _LOGGER.info(_('removing installed modules from environment at %(directory)s' %
                            {'directory': destination}))
-            self._clear_destination_directory(destination)
+            try:
+                shutil.rmtree(destination)
+            except Exception, e:
+                _LOGGER.error(_('error removing environment: %(e)s' % {'e': e}))
+                raise
 
     @staticmethod
     def _find_duplicate_names(units):


### PR DESCRIPTION
https://pulp.plan.io/issues/732

This is an slight modification of the original implementation's behavior.