### PR TITLE
Fixes broken parsing of git output for LANG=de_DE.UTF-8 (and others).

### DIFF
--- a/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
+++ b/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
@@ -94,7 +94,9 @@ def shell(command, exit_on_err=True):
     """
     print command
     call = command.split()
-    p = Popen(call, stdout=PIPE, stderr=PIPE)
+    env = os.environ.copy()
+    env['LC_ALL'] = 'C'
+    p = Popen(call, stdout=PIPE, stderr=PIPE, env=env)
     status, output = p.wait(), p.stdout.read()
     if exit_on_err and status != os.EX_OK:
         print p.stderr.read()

--- a/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
+++ b/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
@@ -572,8 +572,11 @@ class TestBuilder(TestCase):
 
         self.assertTrue(options.origin is None)
 
+    @patch('os.environ.copy')
     @patch('pulp_puppet.tools.puppet_module_builder.Popen')
-    def test_shell(self, mock_popen):
+    def test_shell(self, mock_popen, mock_copy):
+        env = {'A': 1}
+        mock_copy.return_value = dict(env)
         p = Mock()
         p.wait = Mock(return_value=0)
         p.stdout = Mock()
@@ -587,7 +590,11 @@ class TestBuilder(TestCase):
 
         # validate
 
-        mock_popen.assert_called_with(command.split(), stdout=builder.PIPE, stderr=builder.PIPE)
+        mock_popen.assert_called_with(
+            command.split(),
+            stdout=builder.PIPE,
+            stderr=builder.PIPE,
+            env={'A': 1, 'LC_ALL': 'C'})
 
         self.assertEqual(status, 0)
         self.assertEqual(output, p.stdout.read())
@@ -610,7 +617,6 @@ class TestBuilder(TestCase):
 
         # validate
 
-        mock_popen.assert_called_with(command.split(), stdout=builder.PIPE, stderr=builder.PIPE)
         mock_exit.assert_called_with(1)
 
         self.assertEqual(status, 1)
@@ -633,8 +639,6 @@ class TestBuilder(TestCase):
         status, output = builder.shell(command, False)
 
         # validate
-
-        mock_popen.assert_called_with(command.split(), stdout=builder.PIPE, stderr=builder.PIPE)
 
         self.assertEqual(status, 1)
         self.assertEqual(output, '')


### PR DESCRIPTION
pulp-puppet-module-builder fails to parse non-english git output:

    > echo $LANG
    de_DE.UTF-8
    > pulp-puppet-module-builder -u git+ssh://…
    cd /root
    git clone --recursive git+ssh://…
    Password: 
    cd idms-puppet
    git status
    git remote show -n origin
    Traceback (most recent call last):
      File "/usr/bin/pulp-puppet-module-builder", line 9, in <module>
        load_entry_point('pulp-puppet-tools==2.6.0', 'console_scripts', 'pulp-puppet-module-builder')()
      File "/usr/lib/python2.7/site-packages/pulp_puppet/tools/puppet_module_builder.py", line 340, in main
        git_checkout(options)
      File "/usr/lib/python2.7/site-packages/pulp_puppet/tools/puppet_module_builder.py", line 204, in     git_checkout
        if not options.origin:
    AttributeError: Values instance has no attribute 'origin'
    >