### PR TITLE
As a user, I can add mutable custom metadata to a unit.

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -310,7 +310,7 @@ class SynchronizeWithPuppetForge(object):
             module = Module.from_json(metadata_json)
 
             # Update the unit with the extracted metadata
-            unit.metadata = module.unit_metadata()
+            unit.metadata.update(module.unit_metadata())
 
             # Save the unit and associate it to the repository
             self.sync_conduit.save_unit(unit)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
 coverage
-mock
+mock<1.1
 nose
 nosexcover


### PR DESCRIPTION
closes #86
https://pulp.plan.io/issues/86

Unit metadata dictionary needed to be updated and not replaced.