### PR TITLE
Unit tests in pulp_puppet_tools are now run by run-tests.py

### DIFF
--- a/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
+++ b/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
@@ -408,7 +408,7 @@ class TestBuilder(TestCase):
         modules = builder.find_modules()
 
         # validation
-        self.assertEquals(2, mock_shell.call_count)
+        self.assertEquals(1, mock_shell.call_count)
         self.assertEqual(sorted(list(modules)), sorted(['module_1', 'nested/module_2', 'nested/module_3']))
 
     @patch('pulp_puppet.tools.puppet_module_builder.shell')

--- a/run-tests.py
+++ b/run-tests.py
@@ -10,17 +10,20 @@ subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
 PACKAGES = [os.path.dirname(__file__), 'pulp_puppet']
 
-TESTS = [
+EL5_SAFE_TESTS = [
     'pulp_puppet_common/test/unit/',
     'pulp_puppet_extensions_admin/test/unit/',
     'pulp_puppet_extensions_consumer/test/unit/',
     'pulp_puppet_handlers/test/unit/',
 ]
 
-PLUGIN_TESTS = ['pulp_puppet_plugins/test/unit/']
+NON_EL5_TESTS = [
+    'pulp_puppet_plugins/test/unit/',
+    'pulp_puppet_tools/test/unit/',
+]
 
-dir_safe_all_platforms = [os.path.join(os.path.dirname(__file__), x) for x in TESTS]
-dir_safe_non_rhel5 = [os.path.join(os.path.dirname(__file__), x) for x in PLUGIN_TESTS]
+dir_safe_all_platforms = [os.path.join(os.path.dirname(__file__), x) for x in EL5_SAFE_TESTS]
+dir_safe_non_rhel5 = [os.path.join(os.path.dirname(__file__), x) for x in NON_EL5_TESTS]
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pulp_puppet.forge.settings'
 


### PR DESCRIPTION
This also includes a fix for a test in that module that was failing.

closes #1276