### PR TITLE
pulp-puppet-module-builder - Errors if no modules with 'Modulefile' or no modules with 'metadata.json' exist in git repo. Will run puppet module build with no path appended.

### DIFF
--- a/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
+++ b/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
@@ -320,7 +320,7 @@ def clean(options):
     :type options: optparse.Options
     """
     if options.url and options.clean:
-        path = os.path.join(options.working_dir, os.path.basename(options.url))
+        path = os.path.join(options.working_dir, os.path.basename(options.url).split('.')[0])
         shell('rm -rf %s' % path)
 
 

--- a/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
+++ b/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
@@ -227,6 +227,8 @@ def find_modules():
     metadata_status, metadata_output = shell('find . -name metadata.json')
 
     paths = modulefile_output.strip().split('\n') + metadata_output.strip().split('\n')
+    # Remove empty entries from the list, in case all modules use only Modulefile or only metadata.json
+    paths = [x for x in paths if x != '']
     for path in paths:
         path = path.strip()
         path_pieces = path.split('/')


### PR DESCRIPTION
Bug:
 - 'paths' list can contain empty elements if not modules with both 'Modulefile' and 'metadata.json' files are present in the git repo. 'puppet module build' executed with no appended path, exits with error.
Fix:
 - Remove empty strings from the paths list.