### PR TITLE
Fix the usage of import_content in pulp_puppet.

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
@@ -262,8 +262,8 @@ class SynchronizeWithDirectory(object):
             _logger.debug(IMPORT_MODULE, dict(mod=module_path))
 
             module.set_storage_path(os.path.basename(module_path))
-            module.import_content(module_path)
             module.save()
+            module.import_content(module_path)
 
             repo_controller.associate_single_unit(self.repo.repo_obj, module)
 

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -299,8 +299,8 @@ class SynchronizeWithPuppetForge(object):
             # Create and save the Module
             module = Module.from_metadata(metadata)
             module.set_storage_path(os.path.basename(downloaded_filename))
-            module.import_content(downloaded_filename)
             module.save()
+            module.import_content(downloaded_filename)
 
             # Associate the module with the repo
             repo_controller.associate_single_unit(self.repo.repo_obj, module)

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
@@ -45,8 +45,8 @@ def handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path, conduit):
 
     uploaded_module = Module.from_metadata(extracted_data)
     uploaded_module.set_storage_path(os.path.basename(new_file_path))
-    uploaded_module.import_content(new_file_path)
     uploaded_module.save()
+    uploaded_module.import_content(new_file_path)
 
     repo_controller.associate_single_unit(repo.repo_obj, uploaded_module)
     repo_controller.rebuild_content_unit_counts(repo.repo_obj)


### PR DESCRIPTION
The platform recently removed `set_content` and replaced it with
`import_content`. The `import_content` method requires the unit to be
saved prior to calling it, as the unit needs a uuid before its storage
path can be calculated. This commit fixes pulp_puppet to work with
`import_content`.