### PR TITLE
Update python-semantic-version to python-semantic_version in spec.

### DIFF
--- a/pulp-puppet.spec
+++ b/pulp-puppet.spec
@@ -163,7 +163,7 @@ Group: Development/Languages
 Requires: python-pulp-common = %{pulp_version}
 Requires: python-pulp-puppet-common = %{pulp_version}
 Requires: pulp-server = %{pulp_version}
-Requires: python-semantic-version >= 2.2.0
+Requires: python-semantic_version >= 2.2.0
 Requires: python-setuptools
 Requires: python-pycurl
 


### PR DESCRIPTION
The package name has changed to match Fedora's package name: https://github.com/pulp/pulp/commit/c73d1dee8725064485e27797886cbd9936dd415c