### PR TITLE
Update repository units from platform

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
@@ -281,7 +281,6 @@ class SynchronizeWithDirectory(object):
             remove_missing = constants.DEFAULT_REMOVE_MISSING
         if remove_missing:
             self._remove_missing(existing_module_ids_by_key, remote_unit_keys)
-        repo_controller.rebuild_content_unit_counts(self.repo.repo_obj)
 
     def _remove_missing(self, existing_module_ids_by_key, remote_unit_keys):
         """

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -270,7 +270,6 @@ class SynchronizeWithPuppetForge(object):
             doomed_module_iterator = Module.objects.in_bulk(doomed_ids).itervalues()
             repo_controller.disassociate_units(self.repo, doomed_module_iterator)
 
-        repo_controller.rebuild_content_unit_counts(self.repo.repo_obj)
         self.downloader = None
 
     def _add_new_module(self, downloader, module):

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
@@ -49,6 +49,5 @@ def handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path, conduit):
     uploaded_module.import_content(new_file_path)
 
     repo_controller.associate_single_unit(repo.repo_obj, uploaded_module)
-    repo_controller.rebuild_content_unit_counts(repo.repo_obj)
 
     return {'success_flag': True, 'summary': '', 'details': {}}


### PR DESCRIPTION
Updating repository units from platform, due to them
not being reliably updated by plugins. The code to do
this lives in platform, so we should be able to utilize it
from there

https://pulp.plan.io/issues/1467
re #1467