### PR TITLE
Ensure file objects are cleaned up on error

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
@@ -262,8 +262,7 @@ class SynchronizeWithDirectory(object):
             _logger.debug(IMPORT_MODULE, dict(mod=module_path))
 
             module.set_storage_path(os.path.basename(module_path))
-            module.save()
-            module.import_content(module_path)
+            module.save_and_import_content(module_path)
 
             repo_controller.associate_single_unit(self.repo.repo_obj, module)
 

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -298,8 +298,7 @@ class SynchronizeWithPuppetForge(object):
             # Create and save the Module
             module = Module.from_metadata(metadata)
             module.set_storage_path(os.path.basename(downloaded_filename))
-            module.save()
-            module.import_content(downloaded_filename)
+            module.save_and_import_content(downloaded_filename)
 
             # Associate the module with the repo
             repo_controller.associate_single_unit(self.repo.repo_obj, module)

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/upload.py
@@ -45,8 +45,7 @@ def handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path, conduit):
 
     uploaded_module = Module.from_metadata(extracted_data)
     uploaded_module.set_storage_path(os.path.basename(new_file_path))
-    uploaded_module.save()
-    uploaded_module.import_content(new_file_path)
+    uploaded_module.save_and_import_content(new_file_path)
 
     repo_controller.associate_single_unit(repo.repo_obj, uploaded_module)
 

--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_upload.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_upload.py
@@ -52,7 +52,7 @@ class UploadTests(unittest.TestCase):
                                              self.unit_metadata, self.source_file, self.conduit)
 
         # Verify
-        mock_module.from_metadata.return_value.save.assert_called_once_with()
+        mock_module.from_metadata.return_value.save_and_import_content.assert_called_once()
 
         self.assertTrue(isinstance(report, dict))
         self.assertTrue('success_flag' in report)
@@ -72,7 +72,7 @@ class UploadTests(unittest.TestCase):
         report = upload.handle_uploaded_unit(self.repo, constants.TYPE_PUPPET_MODULE, {},
                                              {}, self.source_file, self.conduit)
 
-        mock_module.from_metadata.return_value.save.assert_called_once_with()
+        mock_module.from_metadata.return_value.save_and_import_content.assert_called_once()
 
         self.assertTrue(report['success_flag'])
 


### PR DESCRIPTION
Call save_and_import_content().

re #[1457](https://pulp.plan.io/issues/1457)
https://pulp.plan.io/issues/1457