### PR TITLE
Removes uniqueness constraint on unit key

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/db/models.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/db/models.py
@@ -90,12 +90,6 @@ class Module(FileContentUnit):
     meta = {
         'allow_inheritance': False,
         'collection': 'units_puppet_module',
-        'indexes': [
-            {
-                'fields': unit_key_fields,
-                'unique': True
-            },
-        ],
     }
 
     @classmethod


### PR DESCRIPTION
This uniqueness contstraint is now enforced by the platform for all content units.

https://pulp.plan.io/issues/1477
re: 1477