### PR TITLE
Fix --clean option.

### DIFF
--- a/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
+++ b/pulp_puppet_tools/pulp_puppet/tools/puppet_module_builder.py
@@ -5,6 +5,7 @@ from gettext import gettext as _
 from optparse import OptionParser, OptionGroup
 from subprocess import Popen, PIPE
 from hashlib import sha256
+from urlparse import urlparse
 
 
 PKG_DIR = 'pkg'
@@ -121,6 +122,10 @@ def get_options():
         print BAD_BRANCH_AND_TAG
         sys.exit(os.EX_USAGE)
 
+    # clean url
+    if opts.url:
+        opts.url = opts.url.rstrip('/')
+
     # expand paths
     if opts.working_dir:
         opts.working_dir = os.path.expanduser(opts.working_dir)
@@ -174,8 +179,10 @@ def git_clone(options):
         return
     shell('git clone --recursive %s' % options.url)
     if not options.path:
-        path = os.path.basename(options.url)
-        options.path = path.split('.')[0]
+        url = urlparse(options.url)
+        path = os.path.basename(url.path)
+        path = os.path.splitext(path)[0]
+        options.path = path
 
 
 def git_checkout(options):
@@ -206,21 +213,19 @@ def git_checkout(options):
 def find_modules():
     """
     Search for puppet (source) modules to build and return a list of paths.
-    Puppet modules are identified by finding '<module>/manifests/init.pp'
+    Puppet modules are identified by finding `Modulefile` or `metadata.json`
     files.  Once found, the *module* directory path is included in the result.
 
     :return: A set of puppet module directory paths.
     :rtype: set
     """
     modules = set()
-    # Some old modules contain only 'Modulefile' metadata files, so find both. The set will remove duplicates.
     modules_status, modules_output = shell('find . -name Modulefile -o -name metadata.json')
-
     paths = modules_output.strip().split('\n')
     for path in paths:
         path = path.strip()
         path_pieces = path.split('/')
-        # Puppet makes a PKG_DIR with a copy of the module when built, so don't include those
+        # Puppet makes a PKG_DIR with a copy of the module when built, so don't include those.
         if len(path_pieces) >= 3 and path_pieces[-3] == PKG_DIR:
             continue
         modules.add(os.path.dirname(path))
@@ -308,7 +313,10 @@ def clean(options):
     :type options: optparse.Options
     """
     if options.url and options.clean:
-        path = os.path.join(options.working_dir, os.path.basename(options.url))
+        url = urlparse(options.url)
+        path = os.path.basename(url.path)
+        path = os.path.splitext(path)[0]
+        path = os.path.join(options.working_dir, path)
         shell('rm -rf %s' % path)
 
 

--- a/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
+++ b/pulp_puppet_tools/test/unit/test_puppet_module_builder.py
@@ -3,6 +3,7 @@ import os
 from unittest import TestCase
 from optparse import OptionParser, OptionGroup, Values
 from hashlib import sha256
+from urlparse import urlparse
 
 from mock import Mock, patch
 
@@ -63,6 +64,7 @@ class TestOptions(TestCase):
     @patch('pulp_puppet.tools.puppet_module_builder.OptionParser.parse_args')
     def test_validate_path(self, mock_parse, mock_stdout, mock_exit):
         parsed_options = {
+            'url': None,
             'working_dir': None,
             'output_dir': None,
             'path': '/',
@@ -86,6 +88,7 @@ class TestOptions(TestCase):
     @patch('pulp_puppet.tools.puppet_module_builder.OptionParser.parse_args')
     def test_validate_both_branch_and_tag(self, mock_parse, mock_stdout, mock_exit):
         parsed_options = {
+            'url': None,
             'working_dir': None,
             'output_dir': None,
             'path': None,
@@ -107,6 +110,7 @@ class TestOptions(TestCase):
     @patch('pulp_puppet.tools.puppet_module_builder.OptionParser.parse_args')
     def test_expanded_paths(self, mock_parse):
         parsed_options = {
+            'url': None,
             'working_dir': '~/',
             'output_dir': '~/',
             'path': None,
@@ -126,8 +130,28 @@ class TestOptions(TestCase):
         self.assertEqual(options.output_dir, os.path.expanduser('~/'))
 
     @patch('pulp_puppet.tools.puppet_module_builder.OptionParser.parse_args')
+    def test_clean_url(self, mock_parse):
+        parsed_options = {
+            'url': 'git@test:/pulp/',
+            'working_dir': '~/',
+            'output_dir': '~/',
+            'path': None,
+            'branch': None,
+            'tag': None
+        }
+
+        mock_parse.return_value = (Values(defaults=parsed_options), [])
+
+        # test
+        options = builder.get_options()
+
+        # validation
+        self.assertEqual(options.url, parsed_options['url'].rstrip('/'))
+
+    @patch('pulp_puppet.tools.puppet_module_builder.OptionParser.parse_args')
     def test_defaulting(self, mock_parse):
         parsed_options = {
+            'url': None,
             'working_dir': None,
             'output_dir': None,
             'path': None,
@@ -157,7 +181,7 @@ class TestClean(TestCase):
     @patch('pulp_puppet.tools.puppet_module_builder.shell')
     def test_clean(self, mock_shell):
         parsed_options = {
-            'url': 'http://',
+            'url': 'git@test:foo/bar.git',
             'working_dir': '/tmp/working',
             'clean': True
         }
@@ -169,8 +193,10 @@ class TestClean(TestCase):
         builder.clean(options)
 
         # validation
-
-        path = os.path.join(options.working_dir, os.path.basename(options.url))
+        url = urlparse(options.url)
+        path = os.path.basename(url.path)
+        path = os.path.splitext(path)[0]
+        path = os.path.join(options.working_dir, path)
         mock_shell.assert_called_with('rm -rf %s' % path)
 
     @patch('pulp_puppet.tools.puppet_module_builder.shell')


### PR DESCRIPTION
https://pulp.plan.io/issues/1309

Fix git URLs with trailing /.
Fix --clean to use git checkout directory derived from the URL.
