### PR TITLE
Stop re-raising exceptions during the removal of install_path

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -175,8 +175,7 @@ class PuppetModuleInstallDistributor(Distributor):
             try:
                 shutil.rmtree(destination)
             except Exception, e:
-                _LOGGER.error(_('error removing environment: %(e)s' % {'e': e}))
-                raise
+                _LOGGER.warn(_('error removing environment: %(e)s' % {'e': e}))
 
     @staticmethod
     def _find_duplicate_names(units):

--- a/pulp_puppet_plugins/test/unit/test_install_distributor.py
+++ b/pulp_puppet_plugins/test/unit/test_install_distributor.py
@@ -592,11 +592,11 @@ class TestDistributorRemoved(unittest.TestCase):
 
         mock_rmtree.assert_called_once_with(self.path)
 
-    @mock.patch.object(installdistributor._LOGGER, 'error', spec_set=True)
+    @mock.patch.object(installdistributor._LOGGER, 'warn', spec_set=True)
     @mock.patch('shutil.rmtree', spec_set=True, side_effect=TestException)
     def test_rmtree_exception(self, mock_rmtree, mock_error):
-        self.assertRaises(TestException, self.distributor.distributor_removed, self.repo, self.config)
-        # make sure the error was logged
+        """Test that exception raised by shutil.rmtree won't be re-raised."""
+        self.distributor.distributor_removed(self.repo, self.config)
         self.assertEqual(mock_error.call_count, 1)
 
     @mock.patch('shutil.rmtree', spec_set=True)


### PR DESCRIPTION
https://pulp.plan.io/issues/1607
closes #1607