### PR TITLE
require python-pulp-puppet-common

### DIFF
--- a/pulp-puppet.spec
+++ b/pulp-puppet.spec
@@ -261,6 +261,7 @@ Summary: Pulp puppet tools
 Group: Development/Languages
 Requires: puppet >= 2.7
 Requires: git >= 1.7
+Requires: python-pulp-puppet-common = %{pulp_version}
 
 %description tools
 A collection of tools used to manage puppet modules.


### PR DESCRIPTION
https://pulp.plan.io/issues/538
closes #538

Originally fixed here:
https://github.com/pulp/pulp_puppet/pull/151/

The fix was accidentally removed in a merge conflict.