### PR TITLE
Fixes docs build errors and warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -346,7 +346,7 @@ modules.  It also supports basic `Git <http://git-scm.com>`_ repository operatio
 the checkout of branches and tags to simplify the building and importing of pupppet modules from
 git repositories.
 
-.. see:: ``pulp-puppet-module-builder --help`` for usage and options.
+.. seealso:: ``pulp-puppet-module-builder --help`` for usage and options.
 
 In this example, we will build the ``puppetlabs-xinitd`` module provided by the Puppet Labs git
 repository using ``pulp-puppet-module-builder``.

--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -25,9 +25,11 @@ New Features
 
 - This release drops the following three indexes using a database migration which runs as part of
   the `pulp-manage-db` command:
+
    - `tag_list`
    - `name_1_version_1_author_1`
    - `author`
+
 - This release also adds an index for `author_1_name_1_version_1`
 - The install distributor normalizes uid, gid, and filesystem permissions.
    - Extracted files and directories will inherit the uid and gid of the pulp process that extracts


### PR DESCRIPTION
`make html` now builds cleanly without any errors or warnings.

https://pulp.plan.io/issues/950
re #950