### PR TITLE
Enables strict mode for sphinx docs builds

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
This causes errors to be noticed by the Jenkins job which is the
motivation for this change.

re #950
https://pulp.plan.io/issues/950