### PR TITLE
Forge importer now queries the repo units instead of all units

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/forge.py
@@ -239,7 +239,9 @@ class SynchronizeWithPuppetForge(object):
 
         # Collect information about the repository's modules before changing it
         existing_module_ids_by_key = {}
-        for module in Module.objects.only(*Module.unit_key_fields).all():
+        modules = repo_controller.find_repo_content_units(
+            self.repo.repo_obj, unit_fields=Module.unit_key_fields, yield_content_unit=True)
+        for module in modules:
             existing_module_ids_by_key[module.unit_key_str] = module.id
 
         new_unit_keys = self._resolve_new_units(existing_module_ids_by_key.keys(),


### PR DESCRIPTION
This commit fixes a problem where the Forge importer would skip
importing units into a repository if the unit already existed in Pulp.
This patch does not address the problem that the importer will download
a module even if it already exists within Pulp; that issue is being
tracked in https://pulp.plan.io/issues/1943

fixes #1937