### PR TITLE
Remove intersphinx and enable Strict mode

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.extlinks']
+extensions = ['sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -240,13 +240,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-# the "platform" URL needs to point to the correct version of platform docs for
-# this branch of the plugin. It is currently set to "latest" but may change as
-# code is branched and new RTD builders are created for platform.
-
-intersphinx_mapping = {'pylang': ('http://docs.python.org/2.7/', None),
-                       'platform': ("http://pulp.readthedocs.org/en/latest/", None)}
 
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),
             'fixedbugs': ('https://pulp.plan.io/projects/pulp_puppet/issues?utf8=%%E2%%9C%%93&set'

--- a/docs/user-guide/configuration.rst
+++ b/docs/user-guide/configuration.rst
@@ -11,4 +11,4 @@ The Puppet importer is configured by editing
 
 .. _JSON: http://json.org/
 
-The importer supports the settings documented in Pulp's :ref:`importer config docs <platform:importer_settings>`
+The importer supports the settings documented in Pulp's importer config docs.

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -1,12 +1,11 @@
 Installation
 ============
 
-.. _Pulp User Guide: http://pulp-user-guide.readthedocs.org
+.. _Pulp User Guide: https://docs.pulpproject.org
 
 .. note::
-  If you followed the Pulp :ref:`installation instructions<platform:server_installation>`
-  you already have Puppet features installed. If not, this document will walk
-  you through the installation.
+  If you followed the Pulp installation instructions you already have Puppet
+  features installed. If not, this document will walk you through the installation.
 
 Prerequisites
 -------------

--- a/docs/user-guide/release-notes/2.1.x.rst
+++ b/docs/user-guide/release-notes/2.1.x.rst
@@ -19,7 +19,7 @@ Upgrade the Platform and Pulp Puppet Software
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Please see the
-`Pulp Platform upgrade instructions <https://pulp-user-guide.readthedocs.org/en/pulp-2.1/release-notes.html#upgrade-instructions-for-2-0-2-1>`_
+`Pulp Platform upgrade instructions <https://docs.pulpproject.org/en/latest/user-guide/release-notes/2.1.x.html#upgrade-instructions-for-2-1-0-2-1-1>`_
 to upgrade the Pulp and Puppet RPMs and database.
 
 Republish Puppet Repositories

--- a/docs/user-guide/release-notes/2.2.x.rst
+++ b/docs/user-guide/release-notes/2.2.x.rst
@@ -21,7 +21,7 @@ Upgrade Instructions
 --------------------
 
 Please see the
-`Pulp Platform upgrade instructions <https://pulp-user-guide.readthedocs.org/en/pulp-2.2/release-notes.html>`_
+`Pulp Platform upgrade instructions <https://docs.pulpproject.org/en/latest/user-guide/release-notes/2.2.x.html>`_
 to upgrade the Pulp and Puppet RPMs and database.
 
 


### PR DESCRIPTION
Intersphinx was preventing the strict mode from being enabled
due to docs being built in a network isolated mock environment.

Intersphinx was also going to break because it is tied
to URLs from ReadTheDocs. Now intersphinx is removed, and
usage of it was dropped from the content. Strict Sphinx
mode is now enabled.

Links are also updated to point to docs.pulpproject.org

https://pulp.plan.io/issues/2034
re #2034