### PR TITLE
Add subdir option to puppet install distributor

### DIFF
--- a/docs/tech-reference/plugin_conf.rst
+++ b/docs/tech-reference/plugin_conf.rst
@@ -85,16 +85,16 @@ Install Distributor
 Type ID: ``puppet_install_distributor``
 
 This distributor publishes modules by actually installing them into a given
-``install_path`` on the Pulp server's filesystem. The use case is that you want
+``install_path[/subdir]`` on the Pulp server's filesystem. This is useful when you want
 the contents of a repository to exactly be the collection of modules installed
 in a puppet environment. This allows you to use Pulp's repository management
 features to manage which modules are installed in puppet.
 
 This distributor performs these operations in the following order:
- 1. Creates a temporary directory in the parent directory of ``install_path``.
+ 1. Creates a temporary directory in the parent directory of ``install_path[/subdir]``.
  2. Extracts each module in the repository to that temporary directory.
- 3. Deletes every directory it finds in the ``install_path``.
- 4. Moves the content of temporary directory into the ``install_path``.
+ 3. Deletes every directory it finds in the ``install_path[/subdir]``.
+ 4. Moves the content of temporary directory into the ``install_path[/subdir]``.
  5. Removes the temporary directory.
 
 Extracted files and directories will inherit the uid and gid of the pulp process that extracts them.
@@ -123,6 +123,28 @@ gets deleted, the ``install_path`` and everything in it will be deleted.
  it as your ``install_path`` and you enable the ``pulp_manage_puppet`` boolean, SELinux will allow
  Pulp to write to that path.
 
+``subdir``
+ This is an optional setting to install puppet modules in a subdirectory of the ``install_path``.
+ This allows Pulp to install puppet modules in ``install_path[/subdir]`` and to remove the
+ ``install_path`` directory on distributor removal. If the specified ``subdir`` does not exist
+ it will be created.
+
+ ``subdir`` defaults to None, so if a subdir options is not provided the module is installed in the
+ ``install_path`` directory.
+ An existing repository that wishes to use the ``subdir`` option can update the distributor config.
+
+ Sample Request::
+
+    {
+    "distributor_configs": {
+        "puppet_install_distributor_example":
+            {
+            "install_path":"/etc/puppet/environments/MYENV",
+            "subdir": "modules"
+            }
+         }
+    }
+
 File Distributor
 -------------------
 
@@ -131,7 +153,7 @@ Type ID: ``puppet_file_distributor``
 This distributor publishes modules by making them available in a flattened format in
 a single directory on the file system and served via HTTPS.  The files are published
 to the ``https_files_dir`` specified in the plugin configuration.  A repository is
-placed in a subdirectory of the ```https_files_dir`` with the same name as the repository
+placed in a subdirectory of the ``https_files_dir`` with the same name as the repository
 id.  The base URL path where all Puppet repositories are published is ``/pulp/puppet/files``.
 
 ``https_files_dir``

--- a/docs/user-guide/release-notes/2.13.x.rst
+++ b/docs/user-guide/release-notes/2.13.x.rst
@@ -1,0 +1,21 @@
+=============================
+Pulp Puppet 2.13 Release Notes
+=============================
+
+Pulp Puppet 2.13.0
+=================
+
+New Features
+------------
+
+- Added the ``subdir`` option to the install distributor. This is an optional setting to install
+  puppet modules in a subdirectory in the ``install_path``. This allows Pulp to install puppet
+  modules in ``install_path[/subdir]`` and to remove the ``install_path`` directory on distributor
+  removal. If the specified ``subdir`` does not exist it will be created.
+
+
+Bugs Fixed
+----------
+
+You can see the :fixedbugs:`list of bugs fixed<2.13.0>`.
+

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -1,0 +1,6 @@
+[flake8]
+exclude = ./docs/*, ./playpen/*, */build/*, */backports/*
+# E401: multiple imports on one line
+# W391: blank line at end of file (sadly, it will complain on empty __init__.py files)
+ignore = E401,W391
+max-line-length = 100

--- a/pulp_puppet_common/pulp_puppet/common/constants.py
+++ b/pulp_puppet_common/pulp_puppet/common/constants.py
@@ -119,6 +119,8 @@ DEFAULT_ABSOLUTE_PATH = '/pulp/puppet/'
 
 CONFIG_INSTALL_PATH = 'install_path'
 
+CONFIG_SUBDIR = 'subdir'
+
 # -- forge API ---------------------------------------------------------------
 
 # The puppet forge hostname/IP.

--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -121,9 +121,13 @@ class PuppetModuleInstallDistributor(Distributor):
         """
         # get dir from config
         destination = config.get(constants.CONFIG_INSTALL_PATH)
+        subdir = config.get(constants.CONFIG_SUBDIR)
         if not destination:
             return publish_conduit.build_failure_report(_('install path not provided'),
                                                         self.detail_report.report)
+        if subdir:
+            destination = os.path.join(destination, subdir)
+
         units = list(repo_controller.find_repo_content_units(repo.repo_obj,
                                                              yield_content_unit=True))
         duplicate_units = self._find_duplicate_names(units)


### PR DESCRIPTION
Puppet master modules should be allowed to be installed in a MYENV/modules directory where deleting the puppet repo should remove the MYENV directory. This allows the user
to specify a subdir in which modules could be installed.

closes #2108
https://pulp.plan.io/issues/2108