### PR TITLE
Allow puppet upload errors to propagate

### DIFF
--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -64,7 +64,7 @@ document.
 Missing metadata.json file
 --------------------------
 
-If uploading a puppet module results in `MissingModuleFile` error, one possible problem is that the
+If uploading a puppet module results in `MissingMetadataFile` error, one possible problem is that the
 tar.gz file being uploaded does not contain `metadata.json` file. Another possible problem is
 presence of more than one directory (Puppet module) inside the archive.
 

--- a/pulp_puppet_plugins/pulp_puppet/plugins/db/models.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/db/models.py
@@ -1,19 +1,19 @@
 from mongoengine import ListField, StringField
 from pulp.common.compat import json
 from pulp.server.db.model import FileContentUnit
-from pulp.server.exceptions import InvalidValue
+from pulp.server.exceptions import PulpCodedException
 
 from pulp_puppet.common import constants
+from pulp_puppet.plugins import error_codes
 from pulp_puppet.plugins.importers import metadata as metadata_parser
 
 
-class InvalidModuleName(InvalidValue):
+class InvalidModuleName(PulpCodedException):
     """
-    Raised if the metadata name (author & puppet module name) is invalid
+    Raised if the puppet module name is invalid
     """
-    def __init__(self, name):
-        InvalidValue.__init__(self, 'name')
-        self.name = name
+    def __init__(self, error_code=error_codes.PUP0003, **kwargs):
+        super(InvalidModuleName, self).__init__(error_code=error_code, **kwargs)
 
 
 class RepositoryMetadata(object):
@@ -176,7 +176,7 @@ class Module(FileContentUnit):
                 # This is the forge format, but Puppet still allows it
                 author, name = filename.split("/", 1)
             except ValueError:
-                raise InvalidModuleName(filename)
+                raise InvalidModuleName(name=filename)
 
         return {'author': author, 'name': name}
 

--- a/pulp_puppet_plugins/pulp_puppet/plugins/error_codes.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/error_codes.py
@@ -1,0 +1,8 @@
+from gettext import gettext as _
+
+from pulp.common.error_codes import Error
+
+PUP0001 = Error("PUP0001", _("Could not find metadata file inside Puppet module"), [])
+PUP0002 = Error("PUP0002", _("Could not extract Puppet module."), [])
+PUP0003 = Error("PUP0003", _("Invalid Puppet module name %(name)s in module metadata."),
+                ['name'])

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/importer.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/importer.py
@@ -4,6 +4,7 @@ from gettext import gettext as _
 
 from pulp.plugins.importer import Importer
 from pulp.common.config import read_json_config
+from pulp.server.exceptions import PulpCodedException
 
 from pulp_puppet.common import constants
 from pulp_puppet.plugins.importers import configuration, upload, copier
@@ -77,12 +78,8 @@ class PuppetModuleImporter(Importer):
         return copier.copy_units(import_conduit, units)
 
     def upload_unit(self, repo, type_id, unit_key, metadata, file_path, conduit, config):
-        try:
-            report = upload.handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path,
-                                                 conduit)
-        except Exception, e:
-            _logger.exception(e)
-            report = {'success_flag': False, 'summary': e.message, 'details': {}}
+        report = upload.handle_uploaded_unit(repo, type_id, unit_key, metadata, file_path,
+                                             conduit)
         return report
 
     def cancel_sync_repo(self):

--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_importer.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_importer.py
@@ -72,11 +72,3 @@ class TestPuppetModuleImporter(unittest.TestCase):
         mock_handle_upload.return_value = {'success_flag': True, 'summary': '', 'details': {}}
         report = module_importer.upload_unit(Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock())
         self.assertTrue(report['success_flag'])
-
-    @patch('pulp_puppet.plugins.importers.upload.handle_uploaded_unit')
-    def TestUploadUnitFails(self, mock_handle_upload):
-        module_importer = PuppetModuleImporter()
-        mock_handle_upload.side_effect = Exception('bad')
-        report = module_importer.upload_unit(Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock())
-        self.assertFalse(report['success_flag'])
-        self.assertEquals(report['summary'], 'bad')

--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_upload.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_upload.py
@@ -5,9 +5,9 @@ import unittest
 
 import mock
 from pulp.plugins.model import Repository
+from pulp.server.exceptions import PulpCodedException
 
 from pulp_puppet.common import constants
-from pulp_puppet.plugins.db.models import InvalidModuleName
 from pulp_puppet.plugins.importers import upload
 
 DATA_DIR = os.path.abspath(os.path.dirname(__file__)) + '/../../../data'
@@ -89,7 +89,7 @@ class UploadTests(unittest.TestCase):
     @mock.patch('pulp_puppet.plugins.importers.metadata.extract_metadata')
     def test_handle_uploaded_unit_bad_name(self, mock_metadata):
         mock_metadata.return_value = {'name': 'bad_name'}
-        self.assertRaises(InvalidModuleName, upload.handle_uploaded_unit,
+        self.assertRaises(PulpCodedException, upload.handle_uploaded_unit,
                           self.repo, constants.TYPE_PUPPET_MODULE,
                           self.unit_key, self.unit_metadata, self.source_file,
                           self.conduit)


### PR DESCRIPTION
closes #2512
https://pulp.plan.io/issues/2512