### PR TITLE
Fix remove_missing option and unnecessary downloads for forge importer

### DIFF
--- a/pulp_puppet_extensions_admin/test/unit/extensions/admin/repo/test_cudl.py
+++ b/pulp_puppet_extensions_admin/test/unit/extensions/admin/repo/test_cudl.py
@@ -21,7 +21,7 @@ class CreatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
         expected_options = set([options.OPTION_REPO_ID, options.OPTION_DESCRIPTION,
                                 options.OPTION_NAME, options.OPTION_NOTES,
                                 cudl.OPTION_HTTP, cudl.OPTION_HTTPS, cudl.OPTION_QUERY,
-                                cudl.OPTION_QUERIES])
+                                cudl.OPTION_QUERIES, cudl.OPTION_REMOVE_MISSING])
         found_options = set(self.command.options)
         self.assertEqual(expected_options, found_options)
 
@@ -43,7 +43,8 @@ class CreatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
             cudl.OPTION_HTTP.keyword: 'true',
             cudl.OPTION_HTTPS.keyword: 'true',
             cudl.OPTION_QUERY.keyword: ['q1', 'q2'],
-            cudl.OPTION_QUERIES.keyword: None
+            cudl.OPTION_QUERIES.keyword: None,
+            cudl.OPTION_REMOVE_MISSING.keyword: True
         }
 
         self.server_mock.request.return_value = 200, {}
@@ -69,6 +70,7 @@ class CreatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
         expected_config = {
             u'feed': u'http://localhost',
             u'queries': [u'q1', u'q2'],
+            u'remove_missing': True
         }
         self.assertEqual(expected_config, body['importer_config'])
 
@@ -124,7 +126,8 @@ class UpdatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
         expected_options = set([options.OPTION_REPO_ID, options.OPTION_DESCRIPTION,
                                 options.OPTION_NAME, options.OPTION_NOTES,
                                 cudl.OPTION_HTTP, cudl.OPTION_HTTPS, cudl.OPTION_QUERY,
-                                cudl.OPTION_QUERIES_UPDATE, polling.FLAG_BACKGROUND])
+                                cudl.OPTION_QUERIES_UPDATE, polling.FLAG_BACKGROUND,
+                                cudl.OPTION_REMOVE_MISSING])
         found_options = set(self.command.options)
         self.assertEqual(expected_options, found_options)
 
@@ -145,7 +148,8 @@ class UpdatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
             cudl.OPTION_FEED.keyword: 'http://localhost',
             cudl.OPTION_HTTP.keyword: 'true',
             cudl.OPTION_HTTPS.keyword: 'true',
-            cudl.OPTION_QUERY.keyword: ['q1', 'q2']
+            cudl.OPTION_QUERY.keyword: ['q1', 'q2'],
+            cudl.OPTION_REMOVE_MISSING.keyword: True
         }
         self.mock_repo_response = Mock(response_body={})
         self.context.server.repo = Mock()
@@ -155,7 +159,8 @@ class UpdatePuppetRepositoryCommandTests(base_cli.ExtensionTests):
         self.command.run(**user_input)
         repo_config = {'display_name': 'Test Name', 'description': 'Test Description',
                        'notes': {'a': 'a'}}
-        importer_config = {'feed': 'http://localhost', 'queries': ['q1', 'q2']}
+        importer_config = {'feed': 'http://localhost', 'queries': ['q1', 'q2'],
+                           'remove_missing': True}
         dist_config = {'puppet_distributor': {'serve_https': True, 'serve_http': True}}
         call_details = self.context.server.repo.update.call_args[0]
         self.assertEquals('test-repo', call_details[0])

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/directory.py
@@ -258,7 +258,8 @@ class SynchronizeWithDirectory(object):
             remote_paths[module.unit_key_str] = module_path
             list_of_modules.append(module)
 
-        pub_step = publish_step.GetLocalUnitsStep(constants.IMPORTER_TYPE_ID, available_units=list_of_modules, repo=self.repo)
+        pub_step = publish_step.GetLocalUnitsStep(constants.IMPORTER_TYPE_ID,
+                                                  available_units=list_of_modules, repo=self.repo)
         pub_step.process_main()
         self.report.modules_total_count = len(pub_step.units_to_download)
 
@@ -304,7 +305,7 @@ class SynchronizeWithDirectory(object):
         keys_to_remove = list(set(existing_module_ids_by_key.keys()) - set(remote_unit_keys))
         doomed_ids = [existing_module_ids_by_key[key] for key in keys_to_remove]
         doomed_module_iterator = Module.objects.in_bulk(doomed_ids).itervalues()
-        repo_controller.disassociate_units(self.repo, doomed_module_iterator)
+        repo_controller.disassociate_units(self.repo.repo_obj, doomed_module_iterator)
 
     def __call__(self):
         """

--- a/pulp_puppet_plugins/test/unit/plugins/importer/test_forge.py
+++ b/pulp_puppet_plugins/test/unit/plugins/importer/test_forge.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import shutil
 import tempfile
@@ -9,7 +10,7 @@ from pulp.plugins.config import PluginCallConfiguration
 from pulp.plugins.model import Repository, SyncReport, Unit
 
 from pulp_puppet.common import constants, sync_progress
-from pulp_puppet.plugins.db.models import Module, RepositoryMetadata
+from pulp_puppet.plugins.db.models import Module
 from pulp_puppet.plugins.importers.forge import SynchronizeWithPuppetForge
 
 
@@ -53,11 +54,13 @@ class TestSynchronizeWithPuppetForge(unittest.TestCase):
         self.working_dir = tempfile.mkdtemp(prefix='puppet-sync-tests')
         self.repo = Repository('test-repo', working_dir=self.working_dir)
         self.conduit = MockConduit()
-        self.config = PluginCallConfiguration({}, {
-            constants.CONFIG_FEED : FEED,
-        })
+        self.config = PluginCallConfiguration({}, {constants.CONFIG_FEED: FEED})
 
         self.method = SynchronizeWithPuppetForge(self.repo, self.conduit, self.config)
+
+        self.sample_units = [Module(author='a1', name='n1', version='1.0'),
+                             Module(author='a2', name='n2', version='2.0'),
+                             Module(author='a3', name='n3', version='3.0')]
 
     def tearDown(self):
         shutil.rmtree(self.working_dir)
@@ -215,7 +218,7 @@ class TestSynchronizeWithPuppetForge(unittest.TestCase):
         self.assertEqual(pr.modules_state, constants.STATE_NOT_STARTED)
 
     @mock.patch('pulp_puppet.plugins.importers.forge.SynchronizeWithPuppetForge._do_import_modules')
-    @mock.patch('pulp.server.managers.repo._common.get_working_directory', return_value = '/tmp/')
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory', return_value='/tmp/')
     def test_import_modules_exception(self, mock_get_working_dir, mock_import):
         # Setup
         mock_import.side_effect = Exception()
@@ -242,3 +245,80 @@ class TestSynchronizeWithPuppetForge(unittest.TestCase):
         self.assertTrue(pr.modules_error_message is not None)
         self.assertTrue(pr.modules_exception is not None)
         self.assertTrue(pr.modules_traceback is not None)
+
+    @mock.patch('pulp.plugins.loader.api.get_unit_model_by_id', return_value=Module)
+    @mock.patch('pulp.server.controllers.repository.associate_single_unit')
+    @mock.patch('pulp.server.controllers.units.find_units')
+    @mock.patch('os.path.isfile')
+    def test__resolve_new_units_all_new(self, mock_is_file, mock_find_units, mock_associate,
+                                        mock_get_model):
+        """
+        Test that units which are not in a repo and not downloaded are asked to be downloaded.
+        """
+        existing = []
+        wanted = [unit.unit_key_as_named_tuple for unit in self.sample_units]
+        mock_find_units.return_value = self.sample_units
+
+        units_to_download = self.method._resolve_new_units(existing, wanted)
+
+        self.assertFalse(mock_is_file.called)
+        self.assertFalse(mock_associate.called)
+
+        # check that all units will be asked to be downloaded
+        self.assertEqual(sorted(wanted), sorted(units_to_download))
+
+    @mock.patch('pulp.plugins.loader.api.get_unit_model_by_id', return_value=Module)
+    @mock.patch('pulp.server.controllers.repository.associate_single_unit')
+    @mock.patch('pulp.server.controllers.units.find_units')
+    @mock.patch('os.path.isfile')
+    def test__resolve_new_units_no_new(self, mock_is_file, mock_find_units, mock_associate,
+                                       mock_get_model):
+        """
+        Test that units which are in a repo and downloaded are not asked to be downloaded.
+        """
+        units_with_path = copy.copy(self.sample_units)
+        for unit in units_with_path:
+            unit._storage_path = 'something'
+
+        existing = [unit.unit_key_as_named_tuple for unit in units_with_path]
+        wanted = existing
+        mock_find_units.return_value = self.sample_units
+        mock_is_file.return_value = True
+
+        units_to_download = self.method._resolve_new_units(existing, wanted)
+
+        self.assertEqual(mock_is_file.call_count, 3)
+
+        # all units are already in repo
+        self.assertEqual(mock_associate.call_count, 0)
+
+        # check that no units will be asked to be downloaded
+        self.assertEqual([], units_to_download)
+
+    @mock.patch('pulp.plugins.loader.api.get_unit_model_by_id', return_value=Module)
+    @mock.patch('pulp.server.controllers.repository.associate_single_unit')
+    @mock.patch('pulp.server.controllers.units.find_units')
+    @mock.patch('os.path.isfile')
+    def test__resolve_new_units_downloaded(self, mock_is_file, mock_find_units, mock_associate,
+                                           mock_get_model):
+        """
+        Test that units which are not in a repo but downloaded are not asked to be downloaded.
+        """
+        units_with_path = copy.copy(self.sample_units)
+        for unit in units_with_path:
+            unit._storage_path = 'something'
+
+        existing = []
+        wanted = [unit.unit_key_as_named_tuple for unit in units_with_path]
+        mock_find_units.return_value = self.sample_units
+        mock_is_file.return_value = True
+
+        units_to_download = self.method._resolve_new_units(existing, wanted)
+
+        self.assertEqual(mock_is_file.call_count, 3)
+
+        # all units are already downloaded but were not in repo
+        self.assertEqual(mock_associate.call_count, 3)
+
+        # check that no units will be asked to be downloaded
+        self.assertEqual([], units_to_download)


### PR DESCRIPTION
Fix remove_missing option for the forge and directory importers.
Do not re-download units if they are in DB and on a disk for the forge importer.

closes #2606
https://pulp.plan.io/issues/2606