### PR TITLE
Add provides for python2-* packages

### DIFF
--- a/pulp-puppet.spec
+++ b/pulp-puppet.spec
@@ -138,6 +138,7 @@ rm -rf %{buildroot}
 %package -n python-pulp-puppet-common
 Summary: Pulp Puppet support common library
 Group: Development/Languages
+Provides: python2-pulp-puppet-common
 Requires: python-pulp-common = %{pulp_version}
 Requires: python-setuptools
 


### PR DESCRIPTION
Add provides for python2-* packages.  Fedora downstream packages are
named python2-* and provide python-*.  Upstream needs to mirror this for
dependency resolution to work properly

re #2687