### PR TITLE
Fixing bug where modules had extraneous files

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/metadata.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/metadata.py
@@ -103,10 +103,14 @@ def _extract_json(filename, temp_dir):
     try:
         # Attempt to find the metadata in the Puppet module's main directory
         # It is expected the .tar.gz file will contain exactly one Puppet module
-        try:
-            module_dir = os.listdir(extraction_dir)[0]
-        except IndexError:
+        module_dir = None
+        for module_dir in os.listdir(extraction_dir):
+            if os.path.isdir(module_dir):
+                break
+
+        if module_dir is None:
             raise MissingMetadataFile()
+
         metadata_filename = constants.MODULE_METADATA_FILENAME
         metadata_full_path = os.path.join(extraction_dir, module_dir, metadata_filename)
         if not os.path.isfile(metadata_full_path):


### PR DESCRIPTION
Pulp was unable to find metadata in certain modules that had MacOS
content because it was simply selecting the first file OR dir. Changing
this to filter the list of entries to only dirs.

fixes #1846
https://pulp.plan.io/issues/1846

Note: I couldn't reproduce this in my pulp dev environment. I had to use a Satellite 6.2 box for whatever reason. I'm guessing maybe the ordering of the files is nondeterministic as sometimes the directory gets listed first:

```
(Pdb) os.listdir(extraction_dir)
['marcel-passenger-0.5.0', '._marcel-passenger-0.5.0']
```