### PR TITLE
1237 - distributor config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 This is an alphabetical (by last name) list of the authors of the Pulp Puppet project. If you submit a pull
 request to Pulp Puppet and your name is not on this list, please add yourself.
 
+Ammar Ansari (mansari@redhat.com)
 Randy Barlow (rbarlow@redhat.com)
 Jeremy Cline (jcline@redhat.com)
 Jason L Connor (jason.connor@gmail.com)

--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -98,7 +98,7 @@ class PuppetModuleInstallDistributor(Distributor):
         path = config.get(constants.CONFIG_INSTALL_PATH)
         if not isinstance(path, basestring):
             # path not here, nothing else to validate
-            return True, None
+            return False, _('An install_path has to be specified for the puppet install distributor.')
         if not os.path.isabs(path):
             return False, _('install path is not absolute')
         return True, None

--- a/pulp_puppet_plugins/test/unit/test_install_distributor.py
+++ b/pulp_puppet_plugins/test/unit/test_install_distributor.py
@@ -95,7 +95,7 @@ class TestValidateConfig(unittest.TestCase):
 
         result, message = self.distributor.validate_config(self.repo, config, [])
 
-        self.assertTrue(result)
+        self.assertFalse(result)
 
     def test_relative_path(self):
         config = PluginCallConfiguration({}, {constants.CONFIG_INSTALL_PATH: 'a/b/c'})
@@ -422,20 +422,20 @@ class TestMoveToDestinationDirectory(unittest.TestCase):
         touch(existing_file)
         new_dir = os.path.join(self.source_dir, 'bar')
         os.makedirs(new_dir)
-        installdistributor.PuppetModuleInstallDistributor.\
+        installdistributor.PuppetModuleInstallDistributor. \
             _move_to_destination_directory(self.source_dir, self.destination_dir)
 
         self.assertTrue(os.path.exists(existing_file))
 
     def test_source_dir_removed(self):
-        installdistributor.PuppetModuleInstallDistributor.\
+        installdistributor.PuppetModuleInstallDistributor. \
             _move_to_destination_directory(self.source_dir, self.destination_dir)
         self.assertFalse(os.path.exists(self.source_dir))
 
     def test_move_dirs(self):
         new_dir = os.path.join(self.source_dir, 'bar')
         os.makedirs(new_dir)
-        installdistributor.PuppetModuleInstallDistributor.\
+        installdistributor.PuppetModuleInstallDistributor. \
             _move_to_destination_directory(self.source_dir, self.destination_dir)
 
         self.assertTrue(os.path.exists(os.path.join(self.destination_dir, 'bar')))
@@ -602,7 +602,6 @@ class TestClearDestinationDirectory(unittest.TestCase):
 
 
 class TestCreateTemporaryDestinationDirectory(unittest.TestCase):
-
     def setUp(self):
         self.tmp_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
Added validation to check if distributor_config is specified while associating distributor to repository.

[Issue 1237](https://pulp.plan.io/issues/1237)