### PR TITLE
Advise users on using setsebool to set pulp_manage_rsync selinux boolean

### DIFF
--- a/docs/tech-reference/plugin_conf.rst
+++ b/docs/tech-reference/plugin_conf.rst
@@ -114,10 +114,10 @@ gets deleted, the ``install_path`` and everything in it will be deleted.
  Additionally, the system SELinux policy must permit Pulp to write to this directory. Pulp's SELinux
  policy includes a ``pulp_manage_puppet`` boolean that allows Pulp to write to paths that have the
  ``puppet_etc_t`` label. You must ensure that the ``install_path`` and its parent directory have this
- label applied to it. This boolean is disabled by default for safety. If you wish to enable it, you
- can do this::
+ label applied to it. This boolean is disabled by default for safety. If you wish to enable it,
+ you can do this::
 
-    $ sudo semanage boolean --modify --on pulp_manage_puppet
+    $ sudo setsebool -P pulp_manage_puppet on
 
  ``/etc/puppet/`` has the ``puppet_etc_t`` label by default, so if you use this or a sub directory of
  it as your ``install_path`` and you enable the ``pulp_manage_puppet`` boolean, SELinux will allow


### PR DESCRIPTION
F27+ changed the behavior of semanage to set a selinux boolean by
default, but not change its current state. Update docs to advise users
of this to avoid confusion when rsync distributors fail to run with
selinux in F27.

re #3347
https://pulp.plan.io/issues/3347