### PR TITLE
Docs update

### DIFF
--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -10,13 +10,13 @@ Installation
 Prerequisites
 -------------
 
-Puppet support requires the namespace ``/api/v1/`` at the root of your web server
+Puppet support requires the namespace ``/api/v1/`` or ``/v3/`` at the root of your web server
 in order to implement an API compatible with Puppet Forge. We don't like
-taking that namespace, but it was the only way to support the use of Puppet
-Labs' command line tool against a Pulp server.
+taking that namespace, but it was the only way to support the use of Puppet,
+Inc's command line tool against a Pulp server.
 
-Consumers must have Puppet 2.7.14 to 3.4.3 installed, and we recommend getting packages
-directly from `Puppet Labs <http://puppetlabs.com>`_.
+Consumers must have Puppet 4.10.x to 5.x installed, and we recommend getting packages
+directly from `Puppet, Inc <http://puppet.com>`_.
 
 Please see the `Pulp User Guide`_ for other prerequisites including repository
 setup.

--- a/docs/user-guide/introduction.rst
+++ b/docs/user-guide/introduction.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 Puppet support for Pulp allows you to create and publish repositories of Puppet
-modules. One common use case is to mirror `Puppet Forge <http://forge.puppetlabs.com>`_.
+modules. One common use case is to mirror `Puppet Forge <http://forge.puppet.com>`_.
 You can synchronize an existing repository such as all or part of Puppet Forge,
 upload your own Puppet modules, and publish the result as a repository inside
 your own network.
@@ -12,11 +12,11 @@ additional modules by uploading them directly. This allows you to test new modul
 or new versions of existing modules and then easily promote them into a production
 repository.
 
-Puppet modules must adhere to the Puppet `3.6+ metadata guidelines
-<https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#publishing-modules-on-the-puppet-forge>`_,
+Puppet modules must adhere to the Puppet `4.10+ metadata guidelines
+<https://puppet.com/docs/puppet/4.10/modules_publishing.html>`_,
 which require a valid `metadata.json` file to be present in the puppet module. Also, each tag.gz
 file must contain only one Puppet module inside it. Extra directories or Puppet modules can cause
 unexpected behavior.
 
-Consumers must have Puppet 2.7.14 to 3.4.3 installed, and we recommend getting the Puppet client
-packages directly from `Puppet Labs <http://puppetlabs.com>`_.
+Consumers must have Puppet 4.10.x to 5.x installed, and we recommend getting the Puppet client
+packages directly from `Puppet, Inc <http://puppet.com>`_.

--- a/docs/user-guide/quick-start.rst
+++ b/docs/user-guide/quick-start.rst
@@ -20,7 +20,7 @@ This creates a basic repository that will fetch modules from Puppet Forge.
 
 ::
 
-  $ pulp-admin puppet repo create --repo-id=repo1 --description="Mirror of Puppet Forge" --display-name="Repo 1" --feed=http://forge.puppetlabs.com
+  $ pulp-admin puppet repo create --repo-id=repo1 --description="Mirror of Puppet Forge" --display-name="Repo 1" --feed=http://forge.puppet.com
   Successfully created repository [repo1]
 
 By default, Pulp will serve this repository over HTTP without SSL. Adding
@@ -71,7 +71,7 @@ To include more details, use the ``--details`` flag.
   Notes:
   Importers:
     Config:
-      Feed:    http://forge.puppetlabs.com
+      Feed:    http://forge.puppet.com
       Queries: libvirt
     Id:               puppet_importer
     Importer Type Id: puppet_importer

--- a/docs/user-guide/recipes.rst
+++ b/docs/user-guide/recipes.rst
@@ -10,7 +10,7 @@ any repo-id you like, as long as it is unique within Pulp.
 
 ::
 
-  $ pulp-admin puppet repo create --repo-id=forge --feed=http://forge.puppetlabs.com
+  $ pulp-admin puppet repo create --repo-id=forge --feed=http://forge.puppet.com
   Successfully created repository [forge]
 
 Next synchronize the repository, which downloads all of the modules into the local
@@ -74,116 +74,34 @@ Install Modules
 
 .. _install_post_33:
 
-Installing With Puppet Client 3.3+
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installing With Puppet Client
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To install from a specific pulp repository, the forge URL is formed
-as ``http://<hostname>/pulp_puppet/forge/repository/<repository_id>``. To
+as ``http://.:<repository_id>@<hostname>``. To
 install as a consumer from any bound repository, the URL is formed
-as ``http://<hostname>/pulp_puppet/forge/consumer/<consumer_id>``.
+as ``http://<consumer_id>:.@<hostname>``.
 
 For example, to install module puppetlabs-stdlib from the repository "demo",
 run the following command.
 
 ::
 
-  $ puppet module install --module_repository=http://localhost/pulp_puppet/forge/repository/demo puppetlabs-stdlib
+  $ puppet module install --module_repository=http://.:demo@localhost/ puppetlabs-stdlib
 
 Or to install module puppetlabs-stdlib as the consumer "con1" from any repository
 to which that consumer is bound, run the following command.
 
 ::
 
-  $ puppet module install --module_repository=http://localhost/pulp_puppet/forge/consumer/con1 puppetlabs-stdlib
-
-Installing With Puppet Client < 3.3
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You might notice that this command does not work:
-
-::
-
-  $ puppet module install --module_repository http://localhost/pulp/puppet/forge author/name
-
-For technical reasons described in the note below, the ``puppet module install``
-tool in versions prior to 3.3 ignores the part of the URL after the host name,
-which means we cannot put the repository ID in the URL. We have a work-around
-that will still allow you to use the ``puppet module install`` command with Pulp,
-and it involves the use of basic auth credentials as part of the URL.
-
-.. note:: Puppet Forge implements a web API that their client uses to obtain dependency
-          data when installing a module. Unfortunately, their command line tool has
-          hard-coded absolute paths instead of relative, which means the API must live at
-          the root of a web server. As a result, we cannot put the repository ID in the
-          path as you would expect with the above example.
-
-- **Consumer ID** For a consumer registered with Pulp, just specify its consumer
-  ID as the username in the URL, and a "." for the password. A consumer's ID is a
-  unique identifier just like a username, so this isn't actually a bad use of
-  that field. When a consumer ID is provided, Pulp searches all of that consumer's
-  bound repositories for either the newest version of the requested module, or
-  if a version is specified, searches for the exact version requested. Once a
-  suitable module has been located in a bound repository, all dependency data
-  returned is scoped to that same repository.
-
-::
-
-  $ puppet module install --module_repository http://consumer1:.@localhost
-
-- **Repository ID** For machines that are not bound to a repository, or for a
-  bound machine where you want to specify a repository, do so in the password
-  field. If a repository ID is specified, any value in the username field is
-  ignored. To keep the convention, use a single "." as a null value.
-
-::
-
-  $ puppet module install --module_repository http://.:forge@localhost
-
-The repository URL can be set in ``/etc/puppet/puppet.conf`` so that it
-does not need to be provided on the command line every time. See Puppet's own
-documentation for details.
-
-.. note:: The dependency API from Puppet Forge has been re-implemented by Pulp
-          and can be accessed at /api/v1/releases.json. Puppet Forge also
-          implements a search API that Pulp has not re-implemented due to even
-          more restrictive use of absolute URLs in the puppet tool.
-
-          At this time, Puppet Labs is working on a new version of their API that
-          will include public documentation, and we believe that new API will be
-          much easier to integrate with.
+  $ puppet module install --module_repository=http://con1:.@localhost/ puppetlabs-stdlib
 
 Installing With r10k
 ^^^^^^^^^^^^^^^^^^^^
 
-You can use r10k with Pulp to install a set of Puppet modules specified in a Puppetfile.
-
-The repository URL must be set in the ``r10k.yaml`` configuration file in order for
-r10k to connect to Pulp instead of the default puppet forge. See the r10k
-documentation for details and the specific location of this file in your environment.
-
-
-- **Consumer ID** Simply add the path to the consumer id to the ``baseurl`` parameter of
-  of the ``forge`` option in ``r10k.yaml``.
-
-::
-
-  forge:
-    baseurl: 'http://localhost/pulp_puppet/forge/consumer/con1'
-
-- **Repository ID** For machines that are not bound to a repository, or for a
-  bound machine where you want to specify a repository, update the ``baseurl`` parameter
-  to point at the repository URL.
-
-::
-
-  forge:
-    baseurl: 'http://localhost/pulp_puppet/forge/repository/demo'
-
-.. note:: At this time, Pulp requires that all modules defined in a Puppetfile
-          have their versions explicitly declared. For any modules that do not
-          have versions specified in the Puppetfile, r10k will attempt to search for
-          the latest version of the module by using modules endpoint of the Puppet
-          Forge v3 API, which is not currently supported by Pulp.
+.. note:: r10k is not currently compatible with Pulp due to changes in r10k that now requires
+          the Forge API's ``/v3/modules`` endpoint in addition to the ``/v3/releases`` endpoint.
+          Issue is being tracked in https://pulp.plan.io/issues/1848 
 
 
 Puppet Consumers
@@ -327,7 +245,7 @@ subsequent step. Use any repo-id you like, as long as it is unique within Pulp.
 
 Next, build the puppet modules from source. The ``pulp-puppet-module-builder`` tool is provided
 with Pulp puppet support to make this step easier. The tool uses the
-`puppet module <http://docs.puppetlabs.com/references/3.4.0/man/module.html>`_ tool to build
+`puppet module <https://puppet.com/docs/puppet/4.10/man/module.html>`_ tool to build
 modules.  It also supports basic `Git <http://git-scm.com>`_ repository operations such a cloning and
 the checkout of branches and tags to simplify the building and importing of pupppet modules from
 git repositories.
@@ -414,7 +332,7 @@ and modules are downloaded into a temporary location.
 .. note::
  The ``pulp-puppet-module-builder`` requires that module source layout conform to
  Puppet Labs standard module
- `layout <http://docs.puppetlabs.com/puppet/2.7/reference/modules_fundamentals.html#module-layout>`_
+ `layout <https://puppet.com/docs/puppet/4.10/modules_fundamentals.html#module-layout>`_
 
 
 

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -71,8 +71,8 @@ presence of more than one directory (Puppet module) inside the archive.
 Solution
 ^^^^^^^^
 
-Modules must adhere to the `3.6+ metadata guidlines
-<https://docs.puppetlabs.com/puppet/latest/reference/modules_publishing.html#publishing-modules-on-the-puppet-forge>`_.
+Modules must adhere to the `4.10+ metadata guidlines
+<https://puppet.com/docs/puppet/latest/modules_publishing.html>`_.
 Also ensure that an uploaded archive contains only one Puppet module.
 
 Incorrect Puppet module metadata


### PR DESCRIPTION
The docs have been updated to account for the following:

* Fixing incorrect docs changes I submitted previously
* Updating the Puppet references to correctly reference supported versions of Puppet, which are 4.10.x - 5.x
* Adding note to `r10k` recipe related to https://pulp.plan.io/issues/1848