### PR TITLE
Fixed bug where path wasn't used and module_dir was set to non-directory

### DIFF
--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/installdistributor.py
@@ -98,7 +98,8 @@ class PuppetModuleInstallDistributor(Distributor):
         path = config.get(constants.CONFIG_INSTALL_PATH)
         if not isinstance(path, basestring):
             # path not here, nothing else to validate
-            return False, _('An install_path has to be specified for the puppet install distributor.')
+            return False, _('An install_path has to be specified for the puppet install'
+                            ' distributor.')
         if not os.path.isabs(path):
             return False, _('install path is not absolute')
         return True, None

--- a/pulp_puppet_plugins/pulp_puppet/plugins/distributors/publish.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/distributors/publish.py
@@ -1,5 +1,4 @@
 import gdbm
-import hashlib
 import json
 import logging
 import os

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/importer.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/importer.py
@@ -4,7 +4,6 @@ from gettext import gettext as _
 
 from pulp.plugins.importer import Importer
 from pulp.common.config import read_json_config
-from pulp.server.exceptions import PulpCodedException
 
 from pulp_puppet.common import constants
 from pulp_puppet.plugins.importers import configuration, upload, copier

--- a/pulp_puppet_plugins/pulp_puppet/plugins/importers/metadata.py
+++ b/pulp_puppet_plugins/pulp_puppet/plugins/importers/metadata.py
@@ -104,8 +104,9 @@ def _extract_json(filename, temp_dir):
         # Attempt to find the metadata in the Puppet module's main directory
         # It is expected the .tar.gz file will contain exactly one Puppet module
         module_dir = None
-        for module_dir in os.listdir(extraction_dir):
-            if os.path.isdir(module_dir):
+        for entry in os.listdir(extraction_dir):
+            if os.path.isdir(os.path.join(extraction_dir, entry)):
+                module_dir = entry
                 break
 
         if module_dir is None:


### PR DESCRIPTION
There were two bugs here at play. First the code wasn't using the full
path including extraction_dir when checking if the module file was a
directory and secondly, the loop meant that module_dir could be set to
files if it didn't find a directory.

fixes #4140
https://pulp.plan.io/issues/4140