### PR TITLE
Clearly mark pulp2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
 pulp_puppet
 ===========
 
-Puppet support for the Pulp Platform
+Puppet support for the Pulp 2.y Platform
+


### PR DESCRIPTION
The readme didn't indicate which verison of Pulp it was for. This
clearly marks it as Pulp2.

https://pulp.plan.io/issues/4641
closes #4641